### PR TITLE
Toggle organization sidebar by active tab

### DIFF
--- a/src/views/UserManagement.vue
+++ b/src/views/UserManagement.vue
@@ -29,7 +29,7 @@
 
     <div class="main-container">
       <!-- 左侧组织架构树 -->
-      <div class="sidebar">
+      <div class="sidebar" v-if="activeTab === 'userList'">
         <!-- 搜索框 -->
         <div class="search-header">
           <el-input


### PR DESCRIPTION
## Summary
- show the organization tree only when `activeTab` is `userList`

## Testing
- `npm run lint` *(fails: cannot satisfy repo's lint rules)*

------
https://chatgpt.com/codex/tasks/task_e_687f53afb058832eae9f8273805b50be