### PR TITLE
Add room booking dialog

### DIFF
--- a/src/components/RoomBooking/Booking/BookRoomDialog.vue
+++ b/src/components/RoomBooking/Booking/BookRoomDialog.vue
@@ -1,0 +1,200 @@
+<template>
+  <el-dialog
+    v-model="dialogVisible"
+    title="预约信息"
+    width="800px"
+    :close-on-click-modal="false"
+    @close="handleCancel"
+  >
+    <el-form ref="formRef" :model="form" :rules="rules" label-width="100px">
+      <div class="section">
+        <h4 class="section-title">基本信息</h4>
+        <el-row :gutter="20">
+          <el-col :span="12">
+            <el-form-item label="预约人" prop="applicant">
+              <el-input v-model="form.applicant" placeholder="请输入预约人姓名" />
+            </el-form-item>
+          </el-col>
+          <el-col :span="12">
+            <el-form-item label="预约名称">
+              <el-input v-model="form.bookingName" placeholder="请输入预约名称" />
+            </el-form-item>
+          </el-col>
+        </el-row>
+      </div>
+
+      <div class="section">
+        <h4 class="section-title">借用时间</h4>
+        <el-form-item prop="time">
+          <el-date-picker
+            v-model="form.time"
+            type="datetimerange"
+            range-separator="至"
+            start-placeholder="开始时间"
+            end-placeholder="结束时间"
+            style="width: 100%"
+          />
+        </el-form-item>
+      </div>
+
+      <div class="section">
+        <h4 class="section-title">其他信息</h4>
+        <el-form-item label="借用描述">
+          <el-input v-model="form.description" type="textarea" :rows="3" />
+        </el-form-item>
+        <el-form-item label="参与人">
+          <el-select
+            v-model="form.participants"
+            multiple
+            placeholder="请选择参与人"
+            style="width: 100%"
+          >
+            <el-option
+              v-for="item in memberOptions"
+              :key="item.value"
+              :label="item.label"
+              :value="item.value"
+            />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="备注详情">
+          <el-input v-model="form.remark" type="textarea" :rows="3" />
+        </el-form-item>
+      </div>
+
+      <div class="section">
+        <h4 class="section-title">审批信息</h4>
+        <el-form-item label="审批人" prop="approvers">
+          <el-select
+            v-model="form.approvers"
+            multiple
+            placeholder="请选择审批人"
+            style="width: 100%"
+          >
+            <el-option
+              v-for="item in approverOptions"
+              :key="item.value"
+              :label="item.label"
+              :value="item.value"
+            />
+          </el-select>
+          <div class="tip">选择多人后，任意一个审批人通过即可流转到下一级</div>
+        </el-form-item>
+      </div>
+    </el-form>
+
+    <template #footer>
+      <div class="dialog-footer">
+        <el-button @click="handleCancel">取消</el-button>
+        <el-button type="primary" @click="handleConfirm">确认</el-button>
+      </div>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup>
+import { ref, reactive, watch, nextTick } from 'vue'
+
+const props = defineProps({
+  modelValue: { type: Boolean, default: false },
+  room: { type: Object, default: null }
+})
+
+const emit = defineEmits(['update:modelValue', 'confirm', 'cancel'])
+
+const dialogVisible = ref(false)
+watch(
+  () => props.modelValue,
+  val => {
+    dialogVisible.value = val
+    if (val) {
+      nextTick(() => {
+        resetForm()
+      })
+    }
+  }
+)
+watch(dialogVisible, val => emit('update:modelValue', val))
+
+const formRef = ref()
+
+const form = reactive({
+  applicant: '',
+  bookingName: '',
+  time: [],
+  description: '',
+  participants: [],
+  remark: '',
+  approvers: []
+})
+
+const memberOptions = ref([
+  { label: '张三', value: '张三' },
+  { label: '李四', value: '李四' },
+  { label: '王五', value: '王五' }
+])
+
+const approverOptions = ref([
+  { label: '赵主管', value: '赵主管' },
+  { label: '钱经理', value: '钱经理' },
+  { label: '孙校长', value: '孙校长' }
+])
+
+const rules = {
+  applicant: [{ required: true, message: '请输入预约人姓名', trigger: 'blur' }],
+  time: [{ required: true, message: '请选择借用时间', trigger: 'change' }],
+  approvers: [{ required: true, message: '请选择审批人', trigger: 'change' }]
+}
+
+function resetForm() {
+  form.applicant = ''
+  form.bookingName = ''
+  form.time = []
+  form.description = ''
+  form.participants = []
+  form.remark = ''
+  form.approvers = []
+  formRef.value?.clearValidate()
+}
+
+function handleCancel() {
+  dialogVisible.value = false
+  emit('cancel')
+}
+
+async function handleConfirm() {
+  try {
+    await formRef.value.validate()
+    emit('confirm', { ...form, room: props.room })
+    dialogVisible.value = false
+  } catch (e) {
+    // ignore
+  }
+}
+</script>
+
+<style scoped>
+.section {
+  margin-bottom: 24px;
+}
+
+.section-title {
+  margin-bottom: 12px;
+  font-size: 16px;
+  font-weight: 600;
+  color: #333;
+}
+
+.tip {
+  color: #999;
+  font-size: 12px;
+  margin-top: 4px;
+}
+
+.dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+</style>
+

--- a/src/views/RoomBooking.vue
+++ b/src/views/RoomBooking.vue
@@ -46,7 +46,7 @@
       />
 
       <!-- 设置 -->
-      <SettingsManagement 
+      <SettingsManagement
         v-else-if="activeMainTab === 'settings'"
         :settings-data="settingsData"
         @save-settings="handleSaveSettings"
@@ -58,6 +58,13 @@
         <p>请从导航菜单选择要使用的功能模块</p>
       </div>
     </div>
+
+    <BookRoomDialog
+      v-model="bookDialogVisible"
+      :room="selectedRoom"
+      @confirm="handleBookingConfirm"
+      @cancel="handleBookingCancel"
+    />
   </div>
 </template>
 
@@ -72,6 +79,7 @@ import MainNavigation from '@/components/RoomBooking/Layout/MainNavigation.vue'
 import DashboardContent from '@/components/RoomBooking/Dashboard/DashboardContent.vue'
 import BookingManagement from '@/components/RoomBooking/Booking/BookingManagement.vue'
 import ApprovalManagement from '@/components/RoomBooking/Approval/ApprovalManagement.vue'
+import BookRoomDialog from '@/components/RoomBooking/Booking/BookRoomDialog.vue'
 
 // 延迟加载其他组件（可选优化）
 const RecordsManagement = defineAsyncComponent(() => import('@/components/RoomBooking/Records/RecordsManagement.vue'))
@@ -85,6 +93,7 @@ export default {
     DashboardContent,
     BookingManagement,
     ApprovalManagement,
+    BookRoomDialog,
     RecordsManagement,
     SettingsManagement,
     Document
@@ -92,6 +101,8 @@ export default {
   setup() {
     // 主导航状态
     const activeMainTab = ref('dashboard')
+    const bookDialogVisible = ref(false)
+    const selectedRoom = ref(null)
 
     // 各种数据状态
     const stats = ref({
@@ -277,7 +288,19 @@ export default {
     }
 
     const handleBookRoom = (room) => {
-      ElMessage.info(`预约房间: ${room.name}`)
+      selectedRoom.value = room
+      bookDialogVisible.value = true
+    }
+
+    const handleBookingConfirm = (data) => {
+      ElMessage.success('预约提交成功')
+      bookDialogVisible.value = false
+      selectedRoom.value = null
+    }
+
+    const handleBookingCancel = () => {
+      bookDialogVisible.value = false
+      selectedRoom.value = null
     }
 
     const handleApprovalSubmit = (approval) => {
@@ -333,9 +356,13 @@ export default {
       handleEdit,
       handleApprove,
       handleBookRoom,
+      handleBookingConfirm,
+      handleBookingCancel,
       handleApprovalSubmit,
       handleApprovalReject,
-      handleSaveSettings
+      handleSaveSettings,
+      bookDialogVisible,
+      selectedRoom
     }
   }
 }


### PR DESCRIPTION
## Summary
- add `BookRoomDialog` component for entering reservation info
- integrate dialog with room booking page

## Testing
- `npm install`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f796ec5c8832e9c46b7926f3e9d0a