### PR TITLE
Add mock booking examples

### DIFF
--- a/src/components/RoomBooking/Booking/MyBookings.vue
+++ b/src/components/RoomBooking/Booking/MyBookings.vue
@@ -78,7 +78,12 @@
         </el-table-column>
         <el-table-column prop="usageStatus" label="使用状态" width="100">
           <template #default="{ row }">
-            <el-tag :type="getUsageStatusType(row.usageStatus)" size="small">
+            <span v-if="row.usageStatus === '/'">{{ row.usageStatus }}</span>
+            <el-tag
+              v-else
+              :type="getUsageStatusType(row.usageStatus)"
+              size="small"
+            >
               {{ row.usageStatus }}
             </el-tag>
           </template>
@@ -205,7 +210,8 @@ function getApprovalStatusType(status) {
   const map = {
     审核中: 'warning',
     通过: 'success',
-    拒绝: 'danger'
+    拒绝: 'danger',
+    已取消: 'info'
   }
   return map[status] || 'info'
 }
@@ -214,7 +220,7 @@ function getUsageStatusType(status) {
   const map = {
     未开始: 'info',
     进行中: 'warning',
-    已结束: 'success'
+    已结束: 'info'
   }
   return map[status] || 'info'
 }

--- a/src/views/RoomBooking.vue
+++ b/src/views/RoomBooking.vue
@@ -132,17 +132,47 @@ export default {
         approvalStatus: '通过',
         usageStatus: '未开始'
       },
-      {
-        id: 3,
-        reservationName: '【外聘讲座】演讲厅借用',
-        reservationPeriod: '2025.08.20 星期一 第九节次',
-        description: '外聘教授举办讲座，要求提前布场',
-        applicantName: '赵敏',
-        roomName: '演讲厅（301）',
-        approvalStatus: '通过',
-        usageStatus: '已结束'
-      }
-    ])
+        {
+          id: 3,
+          reservationName: '【外聘讲座】演讲厅借用',
+          reservationPeriod: '2025.08.20 星期一 第九节次',
+          description: '外聘教授举办讲座，要求提前布场',
+          applicantName: '赵敏',
+          roomName: '演讲厅（301）',
+          approvalStatus: '通过',
+          usageStatus: '已结束'
+        },
+        {
+          id: 4,
+          reservationName: '【活动八定名】的教室借用',
+          reservationPeriod: '2025.04.24 第四节次',
+          description: '实验班借用智慧教室用于演示活动',
+          applicantName: '王鹏',
+          roomName: '多媒体教室（101）',
+          approvalStatus: '拒绝',
+          usageStatus: '/'
+        },
+        {
+          id: 5,
+          reservationName: '【活动八定名】的教室借用',
+          reservationPeriod: '2025.04.24 第四节次',
+          description: '实验班借用智慧教室用于演示活动',
+          applicantName: '王鹏',
+          roomName: '多媒体教室（101）',
+          approvalStatus: '通过',
+          usageStatus: '已结束'
+        },
+        {
+          id: 6,
+          reservationName: '【活动八定名】的教室借用',
+          reservationPeriod: '2025.04.24 第四节次',
+          description: '实验班借用智慧教室用于演示活动',
+          applicantName: '王鹏',
+          roomName: '多媒体教室（101）',
+          approvalStatus: '已取消',
+          usageStatus: '/'
+        }
+      ])
 
     const allBookingData = ref([
       {


### PR DESCRIPTION
## Summary
- show `/` usage state as plain text and use grey tag for `已结束`
- support `已取消` approval tag mapping
- insert three sample bookings covering more status combinations

## Testing
- `npm run lint` *(fails: multiple existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688047adbe24832ebe48e23de2a83b38