### PR TITLE
Add audit detail dialog on My Bookings

### DIFF
--- a/src/components/RoomBooking/Booking/AuditDetailDialog.vue
+++ b/src/components/RoomBooking/Booking/AuditDetailDialog.vue
@@ -1,0 +1,117 @@
+<template>
+  <el-dialog
+    v-model="visible"
+    title="审核状态"
+    width="800px"
+    :close-on-click-modal="false"
+  >
+    <el-row gutter="20">
+      <el-col :span="8" class="left-col">
+        <div class="info-item"><label>预约名称：</label><span>{{ info.reservationName }}</span></div>
+        <div class="info-item"><label>预约人：</label><span>{{ info.applicant }}</span></div>
+        <div class="info-item"><label>预约周期：</label><span>{{ info.reservationPeriod }}</span></div>
+        <div class="info-item"><label>借用描述：</label><span>{{ info.description }}</span></div>
+        <div class="info-item"><label>参与人：</label><span>{{ info.participants }}</span></div>
+        <div class="info-item"><label>备注详情：</label><span>{{ info.remark }}</span></div>
+        <div class="info-item">
+          <label>审核状态：</label>
+          <el-tag :type="getStatusType(info.approvalStatus)" size="small">
+            {{ info.approvalStatus }}
+          </el-tag>
+        </div>
+      </el-col>
+      <el-col :span="16" class="right-col">
+        <el-table
+          :data="auditDetails"
+          border
+          stripe
+          height="300"
+          :header-cell-style="{ textAlign: 'center' }"
+          :cell-style="{ textAlign: 'center' }"
+        >
+          <el-table-column prop="level" label="审批层级" width="90" />
+          <el-table-column prop="approvers" label="审批人">
+            <template #default="{ row }">
+              {{ Array.isArray(row.approvers) ? row.approvers.join('，') : row.approvers }}
+            </template>
+          </el-table-column>
+          <el-table-column prop="confirmApprover" label="确认审批人">
+            <template #default="{ row }">
+              {{ row.confirmApprover || '/' }}
+            </template>
+          </el-table-column>
+          <el-table-column prop="time" label="审批时间">
+            <template #default="{ row }">
+              {{ row.time || '/' }}
+            </template>
+          </el-table-column>
+          <el-table-column prop="result" label="审批意见">
+            <template #default="{ row }">
+              <el-tag v-if="row.result" :type="getResultType(row.result)" size="small">
+                {{ row.result }}
+              </el-tag>
+              <span v-else>/</span>
+            </template>
+          </el-table-column>
+        </el-table>
+      </el-col>
+    </el-row>
+    <template #footer>
+      <div class="dialog-footer">
+        <el-button @click="close">取消</el-button>
+      </div>
+    </template>
+  </el-dialog>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  modelValue: { type: Boolean, default: false },
+  info: { type: Object, default: () => ({}) },
+  auditDetails: { type: Array, default: () => [] }
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const visible = computed({
+  get: () => props.modelValue,
+  set: v => emit('update:modelValue', v)
+})
+
+const close = () => {
+  visible.value = false
+}
+
+function getStatusType(status) {
+  const map = {
+    审批中: 'warning',
+    已拒绝: 'danger',
+    已通过: 'success'
+  }
+  return map[status] || 'info'
+}
+
+function getResultType(result) {
+  const map = { 通过: 'success', 拒绝: 'danger' }
+  return map[result] || 'info'
+}
+</script>
+
+<style scoped>
+.left-col {
+  width: 300px;
+}
+.right-col {
+  flex: 1;
+}
+.info-item {
+  margin-bottom: 8px;
+  display: flex;
+  gap: 4px;
+}
+.dialog-footer {
+  text-align: right;
+}
+</style>

--- a/src/components/RoomBooking/Booking/MyBookings.vue
+++ b/src/components/RoomBooking/Booking/MyBookings.vue
@@ -71,7 +71,12 @@
         <el-table-column prop="roomName" label="预约教室" width="150" />
         <el-table-column prop="approvalStatus" label="审核状态" width="100">
           <template #default="{ row }">
-            <el-tag :type="getApprovalStatusType(row.approvalStatus)" size="small">
+            <el-tag
+              :type="getApprovalStatusType(row.approvalStatus)"
+              size="small"
+              class="status-tag"
+              @click="handleViewAuditDetail(row)"
+            >
               {{ row.approvalStatus }}
             </el-tag>
           </template>
@@ -117,12 +122,18 @@
         @current-change="handleCurrentChange"
       />
     </div>
+    <AuditDetailDialog
+      v-model="auditDialogVisible"
+      :info="currentBaseInfo"
+      :audit-details="currentAuditDetails"
+    />
   </div>
 </template>
 
 <script setup>
-import { reactive, computed, watch } from 'vue'
+import { reactive, computed, watch, ref } from 'vue'
 import { Search } from '@element-plus/icons-vue'
+import AuditDetailDialog from './AuditDetailDialog.vue'
 
 const props = defineProps({
   bookingData: {
@@ -141,6 +152,132 @@ const searchForm = reactive({
   startDate: '',
   endDate: ''
 })
+
+// mock 预约基础信息数据
+const bookingBaseInfo = {
+  1: {
+    reservationName: '【活动1】的教室借用',
+    applicant: '王鹏',
+    reservationPeriod: '2025.08.24 星期四 第三节次',
+    description: '班级活动使用，需使用投影设备',
+    participants: '张三, 李四',
+    remark: '需要提前布置',
+    approvalStatus: '审批中'
+  },
+  2: {
+    reservationName: '【学生会】定期会议',
+    applicant: '李明',
+    reservationPeriod: '2025.08.25 星期五 第五节次',
+    description: '学生组织定期内部会议',
+    participants: '刘强, 陈伟',
+    remark: '无',
+    approvalStatus: '已通过'
+  },
+  3: {
+    reservationName: '【外聘讲座】演讲厅借用',
+    applicant: '赵敏',
+    reservationPeriod: '2025.08.20 星期一 第九节次',
+    description: '外聘教授举办讲座，要求提前布场',
+    participants: '张三, 李四, 王五',
+    remark: '讲座需准备扩音设备',
+    approvalStatus: '已通过'
+  },
+  4: {
+    reservationName: '【活动八定名】的教室借用',
+    applicant: '王鹏',
+    reservationPeriod: '2025.04.24 第四节次',
+    description: '实验班借用智慧教室用于演示活动',
+    participants: '李四, 王五',
+    remark: '活动已取消',
+    approvalStatus: '已拒绝'
+  }
+}
+
+// mock 审核详情数据
+const auditDetailData = {
+  1: [
+    {
+      level: '自动审批',
+      approvers: ['系统'],
+      confirmApprover: '系统',
+      time: '2025-08-18 09:00',
+      result: '通过'
+    },
+    {
+      level: '一级',
+      approvers: ['赵主管', '钱经理'],
+      confirmApprover: '赵主管',
+      time: '2025-08-19 10:00',
+      result: '通过'
+    },
+    {
+      level: '二级',
+      approvers: ['孙校长'],
+      confirmApprover: '',
+      time: '',
+      result: '审批中'
+    }
+  ],
+  2: [
+    {
+      level: '自动审批',
+      approvers: ['系统'],
+      confirmApprover: '系统',
+      time: '2025-08-21 09:00',
+      result: '通过'
+    },
+    {
+      level: '一级',
+      approvers: ['赵主管', '钱经理'],
+      confirmApprover: '钱经理',
+      time: '2025-08-22 12:00',
+      result: '通过'
+    },
+    {
+      level: '二级',
+      approvers: ['孙校长'],
+      confirmApprover: '孙校长',
+      time: '2025-08-23 15:00',
+      result: '通过'
+    }
+  ],
+  3: [
+    {
+      level: '自动审批',
+      approvers: ['系统'],
+      confirmApprover: '系统',
+      time: '2025-08-15 08:00',
+      result: '通过'
+    },
+    {
+      level: '一级',
+      approvers: ['赵主管'],
+      confirmApprover: '赵主管',
+      time: '2025-08-16 09:30',
+      result: '通过'
+    }
+  ],
+  4: [
+    {
+      level: '自动审批',
+      approvers: ['系统'],
+      confirmApprover: '系统',
+      time: '2025-04-20 09:00',
+      result: '通过'
+    },
+    {
+      level: '一级',
+      approvers: ['赵主管'],
+      confirmApprover: '赵主管',
+      time: '2025-04-21 11:00',
+      result: '拒绝'
+    }
+  ]
+}
+
+const auditDialogVisible = ref(false)
+const currentBaseInfo = ref({})
+const currentAuditDetails = ref([])
 
 watch(
   () => searchForm.dateRange,
@@ -257,6 +394,12 @@ function handleCancel(row) {
   emit('cancel', row)
 }
 
+function handleViewAuditDetail(row) {
+  currentBaseInfo.value = bookingBaseInfo[row.id] || {}
+  currentAuditDetails.value = auditDetailData[row.id] || []
+  auditDialogVisible.value = true
+}
+
 function handleDateChange(val) {
   if (Array.isArray(val) && val.length === 2) {
     searchForm.startDate = val[0]
@@ -339,6 +482,10 @@ function handleDateChange(val) {
   display: flex;
   justify-content: center;
   padding: 20px 0;
+}
+
+.status-tag {
+  cursor: pointer;
 }
 
 .ellipsis {


### PR DESCRIPTION
## Summary
- add `AuditDetailDialog` component
- open dialog when clicking audit status in MyBookings
- provide mock detail data and base info

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68804ac54dac832e92fcfb6d8c39ad28