### PR TITLE
Improve audit detail modal

### DIFF
--- a/src/components/RoomBooking/Booking/AuditDetailDialog.vue
+++ b/src/components/RoomBooking/Booking/AuditDetailDialog.vue
@@ -1,54 +1,61 @@
 <template>
   <el-dialog
     v-model="visible"
-    title="审核状态"
-    width="800px"
+    title="审核详情"
+    width="900px"
     :close-on-click-modal="false"
   >
-    <el-row gutter="20">
-      <el-col :span="8" class="left-col">
-        <div class="info-item"><label>预约名称：</label><span>{{ info.reservationName }}</span></div>
-        <div class="info-item"><label>预约人：</label><span>{{ info.applicant }}</span></div>
-        <div class="info-item"><label>预约周期：</label><span>{{ info.reservationPeriod }}</span></div>
-        <div class="info-item"><label>借用描述：</label><span>{{ info.description }}</span></div>
-        <div class="info-item"><label>参与人：</label><span>{{ info.participants }}</span></div>
-        <div class="info-item"><label>备注详情：</label><span>{{ info.remark }}</span></div>
-        <div class="info-item">
-          <label>审核状态：</label>
-          <el-tag :type="getStatusType(info.approvalStatus)" size="small">
-            {{ info.approvalStatus }}
-          </el-tag>
-        </div>
+    <el-row :gutter="20">
+      <el-col :span="10" class="left-col">
+        <el-descriptions :column="1" border>
+          <el-descriptions-item label="预约名称">
+            {{ record.reservationTitle || '/' }}
+          </el-descriptions-item>
+          <el-descriptions-item label="预约人">
+            {{ record.userName || '/' }}
+          </el-descriptions-item>
+          <el-descriptions-item label="预约周期">
+            {{ record.borrowPeriodText || '/' }}
+          </el-descriptions-item>
+          <el-descriptions-item label="借用描述">
+            {{ record.borrowDesc || '/' }}
+          </el-descriptions-item>
+          <el-descriptions-item label="参与人">
+            {{ formatArray(record.participants) }}
+          </el-descriptions-item>
+          <el-descriptions-item label="备注信息">
+            {{ record.remark || '/' }}
+          </el-descriptions-item>
+          <el-descriptions-item label="审核状态">
+            <el-tag :type="statusType" size="small">
+              {{ record.approvalStatus || '/' }}
+            </el-tag>
+          </el-descriptions-item>
+        </el-descriptions>
       </el-col>
-      <el-col :span="16" class="right-col">
+      <el-col :span="14" class="right-col">
         <el-table
-          :data="auditDetails"
+          :data="record.approvalSteps || []"
           border
           stripe
           height="300"
           :header-cell-style="{ textAlign: 'center' }"
           :cell-style="{ textAlign: 'center' }"
         >
-          <el-table-column prop="level" label="审批层级" width="90" />
+          <el-table-column prop="levelName" label="审批层级" width="100" />
           <el-table-column prop="approvers" label="审批人">
-            <template #default="{ row }">
-              {{ Array.isArray(row.approvers) ? row.approvers.join('，') : row.approvers }}
-            </template>
+            <template #default="{ row }">{{ formatArray(row.approvers) }}</template>
           </el-table-column>
-          <el-table-column prop="confirmApprover" label="确认审批人">
-            <template #default="{ row }">
-              {{ row.confirmApprover || '/' }}
-            </template>
+          <el-table-column prop="confirmedApprover" label="确认审批人">
+            <template #default="{ row }">{{ row.confirmedApprover || '/' }}</template>
           </el-table-column>
-          <el-table-column prop="time" label="审批时间">
-            <template #default="{ row }">
-              {{ row.time || '/' }}
-            </template>
+          <el-table-column prop="approvalTime" label="审批时间">
+            <template #default="{ row }">{{ row.approvalTime || '/' }}</template>
           </el-table-column>
-          <el-table-column prop="result" label="审批意见">
+          <el-table-column prop="comment" label="审批意见">
             <template #default="{ row }">
-              <el-tag v-if="row.result" :type="getResultType(row.result)" size="small">
-                {{ row.result }}
+              <el-tag v-if="row.comment" :type="commentType(row.comment)" size="small">
+                {{ row.comment }}
               </el-tag>
               <span v-else>/</span>
             </template>
@@ -69,8 +76,7 @@ import { computed } from 'vue'
 
 const props = defineProps({
   modelValue: { type: Boolean, default: false },
-  info: { type: Object, default: () => ({}) },
-  auditDetails: { type: Array, default: () => [] }
+  record: { type: Object, default: () => ({}) }
 })
 
 const emit = defineEmits(['update:modelValue'])
@@ -84,18 +90,25 @@ const close = () => {
   visible.value = false
 }
 
-function getStatusType(status) {
+const formatArray = arr => {
+  if (!arr || arr.length === 0) return '/'
+  return Array.isArray(arr) ? arr.join('，') : arr
+}
+
+const statusType = computed(() => {
   const map = {
-    审批中: 'warning',
+    审核中: 'warning',
     已拒绝: 'danger',
     已通过: 'success'
   }
-  return map[status] || 'info'
-}
+  return map[props.record.approvalStatus] || 'info'
+})
 
-function getResultType(result) {
-  const map = { 通过: 'success', 拒绝: 'danger' }
-  return map[result] || 'info'
+const commentType = comment => {
+  if (!comment) return 'info'
+  if (comment.includes('拒绝')) return 'danger'
+  if (comment.includes('通过') || comment.includes('同意')) return 'success'
+  return 'info'
 }
 </script>
 
@@ -105,11 +118,6 @@ function getResultType(result) {
 }
 .right-col {
   flex: 1;
-}
-.info-item {
-  margin-bottom: 8px;
-  display: flex;
-  gap: 4px;
 }
 .dialog-footer {
   text-align: right;

--- a/src/components/RoomBooking/Booking/MyBookings.vue
+++ b/src/components/RoomBooking/Booking/MyBookings.vue
@@ -124,8 +124,7 @@
     </div>
     <AuditDetailDialog
       v-model="auditDialogVisible"
-      :info="currentBaseInfo"
-      :audit-details="currentAuditDetails"
+      :record="currentRecord"
     />
     <ReservationDetailDialog
       v-model="detailDialogVisible"
@@ -282,8 +281,8 @@ const auditDetailData = {
 }
 
 const auditDialogVisible = ref(false)
-const currentBaseInfo = ref({})
-const currentAuditDetails = ref([])
+// 当前弹窗展示的预约记录
+const currentRecord = ref({})
 const detailDialogVisible = ref(false)
 const reservationDetail = ref({
   userName: '张三',
@@ -434,8 +433,17 @@ function handleCancelReservation() {
 }
 
 function handleViewAuditDetail(row) {
-  currentBaseInfo.value = bookingBaseInfo[row.id] || {}
-  currentAuditDetails.value = auditDetailData[row.id] || []
+  const base = bookingBaseInfo[row.id] || {}
+  currentRecord.value = {
+    reservationTitle: base.reservationName || row.reservationName,
+    userName: base.applicant || row.applicantName,
+    borrowPeriodText: base.reservationPeriod || row.reservationPeriod,
+    borrowDesc: base.description || row.description,
+    participants: base.participants ? base.participants.split(', ') : [],
+    remark: base.remark || '',
+    approvalStatus: base.approvalStatus || row.approvalStatus,
+    approvalSteps: auditDetailData[row.id] || []
+  }
   auditDialogVisible.value = true
 }
 


### PR DESCRIPTION
## Summary
- display correct record information when viewing audit details
- restructure AuditDetailDialog component

## Testing
- `npm run lint` *(fails: 49 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68804fe655cc832e93bb600c683946fc