### PR TITLE
Improve All Bookings interactions

### DIFF
--- a/src/components/RoomBooking/Booking/AllBookings.vue
+++ b/src/components/RoomBooking/Booking/AllBookings.vue
@@ -127,6 +127,15 @@
         @current-change="handleCurrentChange"
       />
     </div>
+    <!-- 审核详情弹窗 -->
+    <AuditDetailDialog v-model="auditDialogVisible" :record="currentRecord" />
+    <!-- 预约详情弹窗，宽度固定为 600px -->
+    <ReservationDetailDialog
+      v-model="detailDialogVisible"
+      :detail="reservationDetail"
+      @cancel="handleCancelReservation"
+      width="600px"
+    />
   </div>
 </template>
 
@@ -154,6 +163,7 @@ const searchForm = reactive({
   endDate: ''
 })
 
+// mock 预约基础信息，涵盖审核中、通过、拒绝、已取消四种状态
 const bookingBaseInfo = {
   1: {
     reservationName: '【活动1】的教室借用',
@@ -162,10 +172,47 @@ const bookingBaseInfo = {
     description: '班级活动使用，需使用投影设备',
     participants: '张三, 李四',
     remark: '需要提前布置',
-    approvalStatus: '审批中'
+    approvalStatus: '审核中'
+  },
+  2: {
+    reservationName: '【学生会】定期会议',
+    applicant: '李明',
+    reservationPeriod: '2025.08.25 星期五 第五节次',
+    description: '学生组织定期内部会议',
+    participants: '刘强, 陈伟',
+    remark: '无',
+    approvalStatus: '通过'
+  },
+  3: {
+    reservationName: '【外聘讲座】演讲厅借用',
+    applicant: '赵敏',
+    reservationPeriod: '2025.08.20 星期一 第九节次',
+    description: '外聘教授举办讲座，要求提前布场',
+    participants: '张三, 李四, 王五',
+    remark: '讲座需准备扩音设备',
+    approvalStatus: '通过'
+  },
+  4: {
+    reservationName: '【活动取消】的教室借用',
+    applicant: '王鹏',
+    reservationPeriod: '2025.04.24 第四节次',
+    description: '实验班借用智慧教室用于演示活动',
+    participants: '李四, 王五',
+    remark: '活动已取消',
+    approvalStatus: '拒绝'
+  },
+  5: {
+    reservationName: '【活动撤销】教室预约',
+    applicant: '张红',
+    reservationPeriod: '2025.04.28 第二节次',
+    description: '社团活动取消，撤销预约',
+    participants: '张红, 李华',
+    remark: '用户主动取消',
+    approvalStatus: '已取消'
   }
 }
 
+// mock 审核详情数据，展示不同状态下的审批流程
 const auditDetailData = {
   1: [
     {
@@ -173,6 +220,77 @@ const auditDetailData = {
       approvers: ['系统'],
       confirmedApprover: '系统',
       approvalTime: '2025-07-21 10:12:33',
+      comment: '系统自动通过'
+    },
+    {
+      levelName: '一级审批',
+      approvers: ['王五', '李四'],
+      confirmedApprover: '',
+      approvalTime: null,
+      comment: ''
+    }
+  ],
+  2: [
+    {
+      levelName: '自动审批',
+      approvers: ['系统'],
+      confirmedApprover: '系统',
+      approvalTime: '2025-08-21 09:00',
+      comment: '系统自动通过'
+    },
+    {
+      levelName: '一级审批',
+      approvers: ['赵主管', '钱经理'],
+      confirmedApprover: '钱经理',
+      approvalTime: '2025-08-22 12:00',
+      comment: '同意：排课正常，无异议'
+    },
+    {
+      levelName: '二级审批',
+      approvers: ['孙校长'],
+      confirmedApprover: '孙校长',
+      approvalTime: '2025-08-23 15:00',
+      comment: '同意：排课正常，无异议'
+    }
+  ],
+  3: [
+    {
+      levelName: '自动审批',
+      approvers: ['系统'],
+      confirmedApprover: '系统',
+      approvalTime: '2025-08-15 08:00',
+      comment: '系统自动通过'
+    },
+    {
+      levelName: '一级审批',
+      approvers: ['赵主管'],
+      confirmedApprover: '赵主管',
+      approvalTime: '2025-08-16 09:30',
+      comment: '同意：排课正常，无异议'
+    }
+  ],
+  4: [
+    {
+      levelName: '自动审批',
+      approvers: ['系统'],
+      confirmedApprover: '系统',
+      approvalTime: '2025-04-20 09:00',
+      comment: '系统自动通过'
+    },
+    {
+      levelName: '一级审批',
+      approvers: ['赵主管'],
+      confirmedApprover: '赵主管',
+      approvalTime: '2025-04-21 11:00',
+      comment: '拒绝：活动已取消'
+    }
+  ],
+  5: [
+    {
+      levelName: '自动审批',
+      approvers: ['系统'],
+      confirmedApprover: '系统',
+      approvalTime: '2025-04-26 09:00',
       comment: '系统自动通过'
     }
   ]

--- a/src/components/RoomBooking/Booking/ReservationDetailDialog.vue
+++ b/src/components/RoomBooking/Booking/ReservationDetailDialog.vue
@@ -1,5 +1,10 @@
 <template>
-  <el-dialog v-model="visible" title="预约详情" :width="dialogWidth" :close-on-click-modal="false">
+<el-dialog
+    v-model="visible"
+    title="预约详情"
+    :width="dialogWidth"
+    :close-on-click-modal="false"
+  >
     <div class="section">
       <el-descriptions :column="2" border>
         <el-descriptions-item label="预约人">
@@ -77,6 +82,7 @@ import { ElMessage } from 'element-plus'
 const props = defineProps({
   modelValue: { type: Boolean, default: false },
   detail: { type: Object, default: () => ({}) },
+  width: { type: String, default: '90%' }
 })
 
 const emit = defineEmits(['update:modelValue', 'cancel'])
@@ -86,7 +92,8 @@ const visible = computed({
   set: (v) => emit('update:modelValue', v),
 })
 
-const dialogWidth = '90%'
+// 对话框宽度可配置，默认为 90%
+const dialogWidth = computed(() => props.width)
 
 const close = () => {
   visible.value = false

--- a/src/views/RoomBooking.vue
+++ b/src/views/RoomBooking.vue
@@ -174,6 +174,7 @@ export default {
         }
       ])
 
+    // 全部借用样例数据，包含审核中、通过、拒绝、已取消
     const allBookingData = ref([
       {
         id: 1,
@@ -182,7 +183,7 @@ export default {
         description: '各类通过这里发布各类信息进行各类信息',
         applicant: '张老师',
         roomName: '多媒体教室（101）',
-        auditStatus: '待审核',
+        auditStatus: '审核中',
         useStatus: '未开始'
       },
       {
@@ -202,8 +203,18 @@ export default {
         description: '新入职教师培训活动',
         applicant: '王主任',
         roomName: '多媒体教室（103）',
-        auditStatus: '通过',
+        auditStatus: '拒绝',
         useStatus: '进行中'
+      },
+      {
+        id: 4,
+        bookingName: '【活动撤销】教室预约',
+        bookingTime: '2025.04.28 第二节次',
+        description: '社团活动取消，撤销预约',
+        applicant: '张红',
+        roomName: '多媒体教室（105）',
+        auditStatus: '已取消',
+        useStatus: '未开始'
       }
     ])
 


### PR DESCRIPTION
## Summary
- tweak ReservationDetailDialog width prop
- support Audit/Reservation dialogs on All Bookings page
- add mock data for all approval states
- update RoomBooking sample data

## Testing
- `npm run lint` *(fails: multiple lint errors across repo)*

------
https://chatgpt.com/codex/tasks/task_e_688073f85bdc832e964fe57f61c9568c