### PR TITLE
Add inner borrow detail view

### DIFF
--- a/src/components/RoomBooking/Records/BorrowDetailDialog.vue
+++ b/src/components/RoomBooking/Records/BorrowDetailDialog.vue
@@ -70,7 +70,9 @@
       <el-table-column prop="usageStatus" label="使用状态" width="100" align="center" />
       <el-table-column label="操作" width="100" align="center" fixed="right">
         <template #default="{ row }">
-          <el-button type="primary" size="small" @click="$emit('view-detail', row)">查看详情</el-button>
+          <el-button type="primary" size="small" @click="openDetail(row)">
+            查看详情
+          </el-button>
         </template>
       </el-table-column>
     </el-table>
@@ -88,6 +90,65 @@
     <template #footer>
       <div class="dialog-footer">
         <el-button @click="visible = false">关闭</el-button>
+      </div>
+    </template>
+  </el-dialog>
+  <el-dialog v-model="detailInnerVisible" title="预约详情" width="600px" :close-on-click-modal="false">
+    <div class="section">
+      <el-row class="field-item">
+        <el-col :span="8" class="label">借用/预约名称：</el-col>
+        <el-col :span="16" class="value">{{ detailRecord.name || '/' }}</el-col>
+      </el-row>
+      <el-row class="field-item">
+        <el-col :span="8" class="label">借用类型：</el-col>
+        <el-col :span="16" class="value">{{ detailRecord.type || '/' }}</el-col>
+      </el-row>
+      <el-row class="field-item">
+        <el-col :span="8" class="label">审核状态：</el-col>
+        <el-col :span="16" class="value">
+          <span :class="statusClass(detailRecord.auditStatus)">{{ detailRecord.auditStatus || '/' }}</span>
+        </el-col>
+      </el-row>
+      <el-row class="field-item">
+        <el-col :span="8" class="label">使用状态：</el-col>
+        <el-col :span="16" class="value">
+          <span :class="statusClass(detailRecord.usageStatus)">{{ detailRecord.usageStatus || '/' }}</span>
+        </el-col>
+      </el-row>
+    </div>
+    <div class="section">
+      <el-row class="field-item">
+        <el-col :span="8" class="label">预约时间：</el-col>
+        <el-col :span="16" class="value">{{ detailRecord.time || '/' }}</el-col>
+      </el-row>
+      <el-row class="field-item">
+        <el-col :span="8" class="label">使用时长：</el-col>
+        <el-col :span="16" class="value">{{ detailRecord.duration || '/' }}</el-col>
+      </el-row>
+    </div>
+    <div class="section">
+      <el-row class="field-item">
+        <el-col :span="8" class="label">预约人：</el-col>
+        <el-col :span="16" class="value">{{ detailRecord.applicant || '/' }}</el-col>
+      </el-row>
+      <el-row class="field-item">
+        <el-col :span="8" class="label">工号：</el-col>
+        <el-col :span="16" class="value">{{ detailRecord.jobNumber || '/' }}</el-col>
+      </el-row>
+      <el-row class="field-item">
+        <el-col :span="8" class="label">联系方式：</el-col>
+        <el-col :span="16" class="value">{{ detailRecord.contact || '/' }}</el-col>
+      </el-row>
+    </div>
+    <div class="section">
+      <el-row class="field-item">
+        <el-col :span="8" class="label">借用描述：</el-col>
+        <el-col :span="16" class="value">{{ detailRecord.description || '/' }}</el-col>
+      </el-row>
+    </div>
+    <template #footer>
+      <div class="dialog-footer">
+        <el-button @click="detailInnerVisible = false">关闭</el-button>
       </div>
     </template>
   </el-dialog>
@@ -121,6 +182,9 @@ const filters = reactive({
 
 const currentPage = ref(1)
 const pageSize = ref(10)
+
+const detailInnerVisible = ref(false)
+const detailRecord = ref({})
 
 const filteredRecords = computed(() => {
   let list = props.recordList
@@ -174,6 +238,24 @@ function exportAll() {
   ElMessage.success('导出全部页')
 }
 
+function openDetail(row) {
+  detailRecord.value = { ...row }
+  detailInnerVisible.value = true
+}
+
+function statusClass(status) {
+  const map = {
+    通过: 'status-green',
+    拒绝: 'status-red',
+    审核中: 'status-blue',
+    已取消: 'status-gray',
+    未开始: 'status-gray',
+    进行中: 'status-blue',
+    已结束: 'status-green'
+  }
+  return map[status] || ''
+}
+
 function auditTagType(status) {
   const map = {
     审核中: 'warning',
@@ -212,6 +294,30 @@ function auditTagType(status) {
 }
 .dialog-footer {
   text-align: right;
+}
+.section {
+  margin-bottom: 20px;
+}
+.field-item {
+  margin-bottom: 8px;
+}
+.label {
+  color: #666;
+}
+.value {
+  color: #333;
+}
+.status-green {
+  color: #67c23a;
+}
+.status-red {
+  color: #f56c6c;
+}
+.status-blue {
+  color: #409eff;
+}
+.status-gray {
+  color: #909399;
 }
 </style>
 


### PR DESCRIPTION
## Summary
- add detail dialog for borrow records
- show record details with colored status labels

## Testing
- `npm run lint` *(fails: multiple existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6880dde3ddd0832eaf68dd7fac01cf22