### PR TITLE
Add authority user details dialog

### DIFF
--- a/src/components/RoomBooking/Settings/AuthorityUserDialog.vue
+++ b/src/components/RoomBooking/Settings/AuthorityUserDialog.vue
@@ -1,0 +1,115 @@
+<template>
+  <el-dialog v-model="visible" title="权限人员" width="600px" destroy-on-close>
+    <div class="filter-area">
+      <el-select v-model="selectedType" style="width: 120px">
+        <el-option label="全部" value="all" />
+        <el-option label="老师" value="teacher" />
+        <el-option label="学生" value="student" />
+      </el-select>
+      <el-input
+        v-model="searchKeyword"
+        placeholder="按姓名或工号搜索"
+        style="width: 200px"
+        clearable
+      >
+        <template #prefix>
+          <el-icon><search /></el-icon>
+        </template>
+      </el-input>
+    </div>
+    <el-table :data="pagedUsers" style="width: 100%" border>
+      <el-table-column prop="name" label="姓名" width="120" />
+      <el-table-column prop="jobNumber" label="工号" width="160" />
+      <el-table-column prop="department" label="所属部门" />
+    </el-table>
+    <div class="pagination-section">
+      <el-pagination
+        v-model:current-page="currentPage"
+        v-model:page-size="pageSize"
+        :total="filteredUsers.length"
+        layout="prev, pager, next"
+      />
+    </div>
+  </el-dialog>
+</template>
+
+<script>
+import { ref, computed, watch } from 'vue'
+import { Search } from '@element-plus/icons-vue'
+
+export default {
+  name: 'AuthorityUserDialog',
+  components: { Search },
+  props: {
+    modelValue: Boolean,
+    users: {
+      type: Array,
+      default: () => []
+    }
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    const visible = ref(props.modelValue)
+    watch(
+      () => props.modelValue,
+      (val) => {
+        visible.value = val
+      }
+    )
+    watch(visible, (val) => emit('update:modelValue', val))
+
+    const selectedType = ref('all')
+    const searchKeyword = ref('')
+    const currentPage = ref(1)
+    const pageSize = ref(10)
+
+    const filteredUsers = computed(() => {
+      let list = props.users
+      if (selectedType.value !== 'all') {
+        list = list.filter((u) => u.type === selectedType.value)
+      }
+      if (searchKeyword.value) {
+        const kw = searchKeyword.value.toLowerCase()
+        list = list.filter(
+          (u) =>
+            u.name.includes(searchKeyword.value) ||
+            String(u.jobNumber).toLowerCase().includes(kw)
+        )
+      }
+      return list
+    })
+
+    const pagedUsers = computed(() => {
+      const start = (currentPage.value - 1) * pageSize.value
+      return filteredUsers.value.slice(start, start + pageSize.value)
+    })
+
+    watch([selectedType, searchKeyword, () => props.users], () => {
+      currentPage.value = 1
+    })
+
+    return {
+      visible,
+      selectedType,
+      searchKeyword,
+      currentPage,
+      pageSize,
+      filteredUsers,
+      pagedUsers
+    }
+  }
+}
+</script>
+
+<style scoped>
+.filter-area {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+.pagination-section {
+  display: flex;
+  justify-content: center;
+  padding-top: 20px;
+}
+</style>

--- a/src/components/RoomBooking/Settings/BookingPersonnelSettings.vue
+++ b/src/components/RoomBooking/Settings/BookingPersonnelSettings.vue
@@ -55,15 +55,23 @@
         </template>
       </el-table-column>
     </el-table>
+    <AuthorityUserDialog
+      v-model="authorityDialogVisible"
+      :users="currentAuthorityUsers"
+    />
   </div>
 </template>
 
 <script>
 import { ref } from 'vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
+import AuthorityUserDialog from './AuthorityUserDialog.vue'
 
 export default {
   name: 'BookingPersonnelSettings',
+  components: {
+    AuthorityUserDialog
+  },
   setup() {
     // 预约人员权限数据 - 根据截图的实际数据结构
     const personnelPermissionData = ref([
@@ -71,6 +79,10 @@ export default {
         id: 1,
         subject: '物理实验室一层、二层、三层可预约人员',
         authorizedPersonnel: '杨超；郭辉；邓伯雯；赵芳；潘欣妍；张宇；吴俊杰；刘敏；孙辉；高颖；王丽；陈杰；周琼；赵诗雅；徐赠；王宇轩；黄斯；李鸥；荣意；贾永强；张良嘉；曹明红；郑子豪......',
+        authorizedUsers: [
+          { name: '张三', jobNumber: 'H0001234', department: '科技处' },
+          { name: '李四', jobNumber: 'H0001235', department: '信息化办公室' }
+        ],
         bookingRooms: '多媒体教室（101）；多媒体教室（102）；多媒体教室（103）；多媒体教室（104）；多媒体教室（105）；多媒体教室（106）；多媒体教室（107）；多媒体教室（108）；多媒体教室（109）；多媒体教室（110）......',
         creator: '张三',
         createTime: '2024.03.08 09:16:26'
@@ -79,11 +91,18 @@ export default {
         id: 2,
         subject: '物理实验室四层可预约人员',
         authorizedPersonnel: '杨超；郭辉；邓伯雯；赵芳；潘欣妍；',
+        authorizedUsers: [
+          { name: '王五', jobNumber: 'H0001236', department: '后勤处' },
+          { name: '赵六', jobNumber: 'H0001237', department: '资产管理处' }
+        ],
         bookingRooms: '清洁间',
         creator: '张三',
         createTime: '2024.03.08 09:16:26'
       }
     ])
+
+    const authorityDialogVisible = ref(false)
+    const currentAuthorityUsers = ref([])
 
     const addPersonnelPermission = () => {
       ElMessage.info('新增预约人员权限功能开发中...')
@@ -94,7 +113,8 @@ export default {
     }
 
     const viewPersonnelDetails = (row) => {
-      ElMessage.info(`查看人员详情: ${row.subject}`)
+      currentAuthorityUsers.value = row.authorizedUsers || []
+      authorityDialogVisible.value = true
     }
 
     const viewRoomDetails = (row) => {
@@ -121,7 +141,9 @@ export default {
       viewPersonnelDetails,
       viewRoomDetails,
       editPersonnelPermission,
-      deletePersonnelPermission
+      deletePersonnelPermission,
+      authorityDialogVisible,
+      currentAuthorityUsers
     }
   }
 }


### PR DESCRIPTION
## Summary
- add **AuthorityUserDialog** component to display permission user details
- include new dialog in booking personnel settings table
- store mock user lists and open the dialog when clicking 查看详情

## Testing
- `npm run build`
- `npm run lint` *(fails: eslint config issues)*

------
https://chatgpt.com/codex/tasks/task_e_688191c43e8c832e98a8070579d0f827