### PR TITLE
Add room permission dialog

### DIFF
--- a/src/components/RoomBooking/Settings/BookingPersonnelSettings.vue
+++ b/src/components/RoomBooking/Settings/BookingPersonnelSettings.vue
@@ -5,12 +5,8 @@
         <h2>预约人员权限列表</h2>
       </div>
       <div class="header-actions">
-        <el-button type="primary" @click="addPersonnelPermission">
-          新增
-        </el-button>
-        <el-button @click="exportPersonnelList">
-          导出
-        </el-button>
+        <el-button type="primary" @click="addPersonnelPermission"> 新增 </el-button>
+        <el-button @click="exportPersonnelList"> 导出 </el-button>
       </div>
     </div>
 
@@ -20,11 +16,11 @@
         <template #default="{ row }">
           <div class="personnel-text">
             {{ row.authorizedPersonnel }}
-            <el-button 
-              type="text" 
-              size="small" 
+            <el-button
+              type="text"
+              size="small"
               @click="viewPersonnelDetails(row)"
-              style="color: #409EFF; margin-left: 10px;"
+              style="color: #409eff; margin-left: 10px"
             >
               查看详情
             </el-button>
@@ -35,11 +31,11 @@
         <template #default="{ row }">
           <div class="rooms-text">
             {{ row.bookingRooms }}
-            <el-button 
-              type="text" 
-              size="small" 
+            <el-button
+              type="text"
+              size="small"
               @click="viewRoomDetails(row)"
-              style="color: #409EFF; margin-left: 10px;"
+              style="color: #409eff; margin-left: 10px"
             >
               查看详情
             </el-button>
@@ -50,15 +46,17 @@
       <el-table-column prop="createTime" label="创建时间" width="120" />
       <el-table-column label="操作" width="150">
         <template #default="{ row }">
-          <el-button type="primary" size="small" @click="editPersonnelPermission(row)">编辑</el-button>
-          <el-button type="danger" size="small" @click="deletePersonnelPermission(row)">删除</el-button>
+          <el-button type="primary" size="small" @click="editPersonnelPermission(row)"
+            >编辑</el-button
+          >
+          <el-button type="danger" size="small" @click="deletePersonnelPermission(row)"
+            >删除</el-button
+          >
         </template>
       </el-table-column>
     </el-table>
-    <AuthorityUserDialog
-      v-model="authorityDialogVisible"
-      :users="currentAuthorityUsers"
-    />
+    <AuthorityUserDialog v-model="authorityDialogVisible" :users="currentAuthorityUsers" />
+    <PermissionRoomDialog v-model="roomDialogVisible" :rooms="currentPermissionRooms" />
   </div>
 </template>
 
@@ -66,11 +64,13 @@
 import { ref } from 'vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import AuthorityUserDialog from './AuthorityUserDialog.vue'
+import PermissionRoomDialog from './PermissionRoomDialog.vue'
 
 export default {
   name: 'BookingPersonnelSettings',
   components: {
-    AuthorityUserDialog
+    AuthorityUserDialog,
+    PermissionRoomDialog,
   },
   setup() {
     // 预约人员权限数据 - 根据截图的实际数据结构
@@ -78,14 +78,20 @@ export default {
       {
         id: 1,
         subject: '物理实验室一层、二层、三层可预约人员',
-        authorizedPersonnel: '杨超；郭辉；邓伯雯；赵芳；潘欣妍；张宇；吴俊杰；刘敏；孙辉；高颖；王丽；陈杰；周琼；赵诗雅；徐赠；王宇轩；黄斯；李鸥；荣意；贾永强；张良嘉；曹明红；郑子豪......',
+        authorizedPersonnel:
+          '杨超；郭辉；邓伯雯；赵芳；潘欣妍；张宇；吴俊杰；刘敏；孙辉；高颖；王丽；陈杰；周琼；赵诗雅；徐赠；王宇轩；黄斯；李鸥；荣意；贾永强；张良嘉；曹明红；郑子豪......',
         authorizedUsers: [
           { name: '张三', jobNumber: 'H0001234', department: '科技处' },
-          { name: '李四', jobNumber: 'H0001235', department: '信息化办公室' }
+          { name: '李四', jobNumber: 'H0001235', department: '信息化办公室' },
         ],
-        bookingRooms: '多媒体教室（101）；多媒体教室（102）；多媒体教室（103）；多媒体教室（104）；多媒体教室（105）；多媒体教室（106）；多媒体教室（107）；多媒体教室（108）；多媒体教室（109）；多媒体教室（110）......',
+        bookingRooms:
+          '多媒体教室（101）；多媒体教室（102）；多媒体教室（103）；多媒体教室（104）；多媒体教室（105）；多媒体教室（106）；多媒体教室（107）；多媒体教室（108）；多媒体教室（109）；多媒体教室（110）......',
+        roomList: [
+          { roomName: '多媒体教室（101）', roomCode: '101', building: '科研楼' },
+          { roomName: '多媒体教室（102）', roomCode: '102', building: '科研楼' },
+        ],
         creator: '张三',
-        createTime: '2024.03.08 09:16:26'
+        createTime: '2024.03.08 09:16:26',
       },
       {
         id: 2,
@@ -93,16 +99,19 @@ export default {
         authorizedPersonnel: '杨超；郭辉；邓伯雯；赵芳；潘欣妍；',
         authorizedUsers: [
           { name: '王五', jobNumber: 'H0001236', department: '后勤处' },
-          { name: '赵六', jobNumber: 'H0001237', department: '资产管理处' }
+          { name: '赵六', jobNumber: 'H0001237', department: '资产管理处' },
         ],
         bookingRooms: '清洁间',
+        roomList: [{ roomName: '清洁间', roomCode: '401', building: '达才楼' }],
         creator: '张三',
-        createTime: '2024.03.08 09:16:26'
-      }
+        createTime: '2024.03.08 09:16:26',
+      },
     ])
 
     const authorityDialogVisible = ref(false)
     const currentAuthorityUsers = ref([])
+    const roomDialogVisible = ref(false)
+    const currentPermissionRooms = ref([])
 
     const addPersonnelPermission = () => {
       ElMessage.info('新增预约人员权限功能开发中...')
@@ -118,7 +127,8 @@ export default {
     }
 
     const viewRoomDetails = (row) => {
-      ElMessage.info(`查看房间详情: ${row.subject}`)
+      currentPermissionRooms.value = row.roomList || []
+      roomDialogVisible.value = true
     }
 
     const editPersonnelPermission = (row) => {
@@ -143,9 +153,11 @@ export default {
       editPersonnelPermission,
       deletePersonnelPermission,
       authorityDialogVisible,
-      currentAuthorityUsers
+      currentAuthorityUsers,
+      roomDialogVisible,
+      currentPermissionRooms,
     }
-  }
+  },
 }
 </script>
 

--- a/src/components/RoomBooking/Settings/PermissionRoomDialog.vue
+++ b/src/components/RoomBooking/Settings/PermissionRoomDialog.vue
@@ -1,0 +1,110 @@
+<template>
+  <el-dialog v-model="visible" title="可预约房屋/教室" width="600px" destroy-on-close>
+    <div class="filter-area">
+      <el-select v-model="selectedBuilding" style="width: 150px">
+        <el-option label="全部" value="all" />
+        <el-option v-for="b in buildingOptions" :key="b" :label="b" :value="b" />
+      </el-select>
+      <el-input v-model="searchKeyword" placeholder="按教室名称搜索" clearable style="width: 200px">
+        <template #prefix>
+          <el-icon><Search /></el-icon>
+        </template>
+      </el-input>
+    </div>
+    <el-table :data="pagedRooms" style="width: 100%" border>
+      <el-table-column prop="roomName" label="预约教室" />
+      <el-table-column prop="roomCode" label="房间号" width="100" />
+      <el-table-column prop="building" label="所属楼栋" />
+    </el-table>
+    <div class="pagination-section">
+      <el-pagination
+        v-model:current-page="currentPage"
+        v-model:page-size="pageSize"
+        :total="filteredRooms.length"
+        layout="prev, pager, next"
+      />
+    </div>
+  </el-dialog>
+</template>
+
+<script>
+import { ref, computed, watch } from 'vue'
+import { Search } from '@element-plus/icons-vue'
+
+export default {
+  name: 'PermissionRoomDialog',
+  components: { Search },
+  props: {
+    modelValue: Boolean,
+    rooms: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    const visible = ref(props.modelValue)
+    watch(
+      () => props.modelValue,
+      (val) => {
+        visible.value = val
+      },
+    )
+    watch(visible, (val) => emit('update:modelValue', val))
+
+    const selectedBuilding = ref('all')
+    const searchKeyword = ref('')
+    const currentPage = ref(1)
+    const pageSize = ref(10)
+
+    const buildingOptions = computed(() => {
+      const set = new Set(props.rooms.map((r) => r.building))
+      return Array.from(set)
+    })
+
+    const filteredRooms = computed(() => {
+      let list = props.rooms
+      if (selectedBuilding.value !== 'all') {
+        list = list.filter((r) => r.building === selectedBuilding.value)
+      }
+      if (searchKeyword.value) {
+        list = list.filter((r) => r.roomName.includes(searchKeyword.value))
+      }
+      return list
+    })
+
+    const pagedRooms = computed(() => {
+      const start = (currentPage.value - 1) * pageSize.value
+      return filteredRooms.value.slice(start, start + pageSize.value)
+    })
+
+    watch([selectedBuilding, searchKeyword, () => props.rooms], () => {
+      currentPage.value = 1
+    })
+
+    return {
+      visible,
+      selectedBuilding,
+      searchKeyword,
+      currentPage,
+      pageSize,
+      buildingOptions,
+      filteredRooms,
+      pagedRooms,
+    }
+  },
+}
+</script>
+
+<style scoped>
+.filter-area {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+.pagination-section {
+  display: flex;
+  justify-content: center;
+  padding-top: 20px;
+}
+</style>


### PR DESCRIPTION
## Summary
- add `PermissionRoomDialog` component for viewing available rooms
- wire dialog into booking personnel settings with new `roomList` sample data

## Testing
- `npm run lint` *(fails: 42 errors)*
- `npx prettier --write src/components/RoomBooking/Settings/PermissionRoomDialog.vue src/components/RoomBooking/Settings/BookingPersonnelSettings.vue`

------
https://chatgpt.com/codex/tasks/task_e_688197bb95ec832eaed3ff01ca8c456c