### PR TITLE
Fix permission edit dialog visibility

### DIFF
--- a/src/components/RoomBooking/Settings/BookingPersonnelSettings.vue
+++ b/src/components/RoomBooking/Settings/BookingPersonnelSettings.vue
@@ -57,6 +57,15 @@
     </el-table>
     <AuthorityUserDialog v-model="authorityDialogVisible" :users="currentAuthorityUsers" />
     <PermissionRoomDialog v-model="roomDialogVisible" :rooms="currentPermissionRooms" />
+    <PermissionEditDialog
+      v-model:visible="editDialogVisible"
+      :isEdit="isEdit"
+      :userList="[]"
+      :roomList="[]"
+      :selectedUsers="selectedUserData"
+      :selectedRooms="selectedRoomData"
+      @submit="handlePermissionSubmit"
+    />
   </div>
 </template>
 
@@ -65,12 +74,14 @@ import { ref } from 'vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import AuthorityUserDialog from './AuthorityUserDialog.vue'
 import PermissionRoomDialog from './PermissionRoomDialog.vue'
+import PermissionEditDialog from './PermissionEditDialog.vue'
 
 export default {
   name: 'BookingPersonnelSettings',
   components: {
     AuthorityUserDialog,
     PermissionRoomDialog,
+    PermissionEditDialog,
   },
   setup() {
     // 预约人员权限数据 - 根据截图的实际数据结构
@@ -113,8 +124,16 @@ export default {
     const roomDialogVisible = ref(false)
     const currentPermissionRooms = ref([])
 
+    const editDialogVisible = ref(false)
+    const isEdit = ref(false)
+    const selectedUserData = ref([])
+    const selectedRoomData = ref([])
+
     const addPersonnelPermission = () => {
-      ElMessage.info('新增预约人员权限功能开发中...')
+      isEdit.value = false
+      selectedUserData.value = []
+      selectedRoomData.value = []
+      editDialogVisible.value = true
     }
 
     const exportPersonnelList = () => {
@@ -132,7 +151,10 @@ export default {
     }
 
     const editPersonnelPermission = (row) => {
-      ElMessage.info(`编辑权限设置: ${row.subject}`)
+      isEdit.value = true
+      selectedUserData.value = row.authorizedUsers || []
+      selectedRoomData.value = row.roomList || []
+      editDialogVisible.value = true
     }
 
     const deletePersonnelPermission = async (row) => {
@@ -144,6 +166,12 @@ export default {
       }
     }
 
+    const handlePermissionSubmit = (payload) => {
+      console.log('提交的权限配置：', payload)
+      ElMessage.success('权限配置已提交')
+      editDialogVisible.value = false
+    }
+
     return {
       personnelPermissionData,
       addPersonnelPermission,
@@ -152,10 +180,15 @@ export default {
       viewRoomDetails,
       editPersonnelPermission,
       deletePersonnelPermission,
+      handlePermissionSubmit,
       authorityDialogVisible,
       currentAuthorityUsers,
       roomDialogVisible,
       currentPermissionRooms,
+      editDialogVisible,
+      isEdit,
+      selectedUserData,
+      selectedRoomData,
     }
   },
 }

--- a/src/components/RoomBooking/Settings/PermissionEditDialog.vue
+++ b/src/components/RoomBooking/Settings/PermissionEditDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <el-dialog
-    v-model="dialogVisible"
+    v-model:visible="visible"
     :title="isEdit ? '编辑权限配置' : '新增权限配置'"
     width="900px"
     destroy-on-close
@@ -159,7 +159,10 @@ export default {
   },
   emits: ['update:visible', 'submit'],
   setup(props, { emit }) {
-    const dialogVisible = ref(false)
+    const visible = computed({
+      get: () => props.visible,
+      set: (val) => emit('update:visible', val)
+    })
 
     const userFilter = reactive({
       type: 'all',
@@ -189,17 +192,12 @@ export default {
     watch(
       () => props.visible,
       (val) => {
-        dialogVisible.value = val
         if (val) {
           userData.value = [...props.selectedUsers]
           roomData.value = [...props.selectedRooms]
         }
       }
     )
-
-    watch(dialogVisible, (val) => {
-      emit('update:visible', val)
-    })
 
     const filterListByTypeAndKeyword = (list, filter) => {
       let result = list
@@ -282,7 +280,7 @@ export default {
     }
 
     const handleClose = () => {
-      dialogVisible.value = false
+      emit('update:visible', false)
     }
 
     const handleSubmit = () => {
@@ -295,7 +293,7 @@ export default {
 
     return {
       Search,
-      dialogVisible,
+      visible,
       userFilter,
       roomFilter,
       userPage,


### PR DESCRIPTION
## Summary
- register and mount PermissionEditDialog
- manage visibility and data when adding or editing permissions
- use `v-model:visible` in PermissionEditDialog
- synchronize dialog visibility with parent

## Testing
- `npm run lint` *(fails: 44 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6881a483f964832e87803831b94f88fc