### PR TITLE
Implement RBAC security with JWT

### DIFF
--- a/backend/src/main/java/com/proshine/system/config/SecurityConfig.java
+++ b/backend/src/main/java/com/proshine/system/config/SecurityConfig.java
@@ -1,19 +1,49 @@
 package com.proshine.system.config;
 
+import com.proshine.system.security.JwtAuthenticationFilter;
+import com.proshine.system.security.CustomUserDetailsService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtFilter;
+    private final CustomUserDetailsService userDetailsService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.csrf().disable()
-            .authorizeRequests().anyRequest().permitAll();
+            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            .and()
+            .authorizeRequests()
+            .antMatchers("/authentication/**").permitAll()
+            .anyRequest().authenticated();
+        http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
     }
 }

--- a/backend/src/main/java/com/proshine/system/controller/AdminManagementController.java
+++ b/backend/src/main/java/com/proshine/system/controller/AdminManagementController.java
@@ -1,0 +1,26 @@
+package com.proshine.system.controller;
+
+import com.proshine.common.response.ResponseEntity;
+import com.proshine.system.dto.AssignRoleRequest;
+import com.proshine.system.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin-management")
+@RequiredArgsConstructor
+public class AdminManagementController {
+
+    private final UserService userService;
+
+    @PostMapping("/assign-role")
+    @PreAuthorize("hasAuthority('user:assign')")
+    public ResponseEntity<Void> assignRole(@RequestBody AssignRoleRequest req) {
+        userService.assignRole(req.getUserId(), req.getRoleIds());
+        return ResponseEntity.success(null);
+    }
+}

--- a/backend/src/main/java/com/proshine/system/controller/AuthenticationController.java
+++ b/backend/src/main/java/com/proshine/system/controller/AuthenticationController.java
@@ -1,0 +1,37 @@
+package com.proshine.system.controller;
+
+import com.proshine.common.response.ResponseEntity;
+import com.proshine.system.dto.LoginRequest;
+import com.proshine.system.dto.LoginResponse;
+import com.proshine.system.entity.User;
+import com.proshine.system.security.JwtUtil;
+import com.proshine.system.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/authentication")
+@RequiredArgsConstructor
+public class AuthenticationController {
+
+    private final UserService userService;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
+        User user = userService.findByUsername(request.getUsername());
+        if (user == null || !passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            return ResponseEntity.fail("invalid credentials");
+        }
+        String token = jwtUtil.generateToken(user.getId(), user.getUsername());
+        List<String> codes = userService.getPermissionCodes(user.getId());
+        LoginResponse resp = new LoginResponse();
+        resp.setToken(token);
+        resp.setPermissionCodes(codes);
+        return ResponseEntity.success(resp);
+    }
+}

--- a/backend/src/main/java/com/proshine/system/controller/PersonalCenterController.java
+++ b/backend/src/main/java/com/proshine/system/controller/PersonalCenterController.java
@@ -1,0 +1,32 @@
+package com.proshine.system.controller;
+
+import com.proshine.common.response.ResponseEntity;
+import com.proshine.system.dto.UserProfileDto;
+import com.proshine.system.entity.User;
+import com.proshine.system.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/personal-center")
+@RequiredArgsConstructor
+public class PersonalCenterController {
+
+    private final UserService userService;
+
+    @GetMapping("/profile")
+    public ResponseEntity<UserProfileDto> profile(@AuthenticationPrincipal UserDetails userDetails) {
+        User user = userService.findByUsername(userDetails.getUsername());
+        List<String> codes = userService.getPermissionCodes(user.getId());
+        UserProfileDto dto = new UserProfileDto();
+        dto.setUser(user);
+        dto.setPermissionCodes(codes);
+        return ResponseEntity.success(dto);
+    }
+}

--- a/backend/src/main/java/com/proshine/system/controller/RoleManagementController.java
+++ b/backend/src/main/java/com/proshine/system/controller/RoleManagementController.java
@@ -1,0 +1,32 @@
+package com.proshine.system.controller;
+
+import com.proshine.common.response.ResponseEntity;
+import com.proshine.system.dto.AssignPermissionsRequest;
+import com.proshine.system.entity.Permission;
+import com.proshine.system.service.RoleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/role-management")
+@RequiredArgsConstructor
+public class RoleManagementController {
+
+    private final RoleService roleService;
+
+    @GetMapping("/permissions")
+    public ResponseEntity<List<Permission>> permissions() {
+        List<Permission> list = roleService.allPermissions();
+        return ResponseEntity.success(list);
+    }
+
+    @PostMapping("/assign-permissions")
+    @PreAuthorize("hasAuthority('role:assign')")
+    public ResponseEntity<Void> assignPermissions(@RequestBody AssignPermissionsRequest req) {
+        roleService.assignPermissions(req.getRoleId(), req.getPermissionIds());
+        return ResponseEntity.success(null);
+    }
+}

--- a/backend/src/main/java/com/proshine/system/dto/AssignPermissionsRequest.java
+++ b/backend/src/main/java/com/proshine/system/dto/AssignPermissionsRequest.java
@@ -1,0 +1,11 @@
+package com.proshine.system.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class AssignPermissionsRequest {
+    private String roleId;
+    private List<String> permissionIds;
+}

--- a/backend/src/main/java/com/proshine/system/dto/AssignRoleRequest.java
+++ b/backend/src/main/java/com/proshine/system/dto/AssignRoleRequest.java
@@ -1,0 +1,11 @@
+package com.proshine.system.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class AssignRoleRequest {
+    private String userId;
+    private List<String> roleIds;
+}

--- a/backend/src/main/java/com/proshine/system/dto/LoginRequest.java
+++ b/backend/src/main/java/com/proshine/system/dto/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.proshine.system.dto;
+
+import lombok.Data;
+
+@Data
+public class LoginRequest {
+    private String username;
+    private String password;
+}

--- a/backend/src/main/java/com/proshine/system/dto/LoginResponse.java
+++ b/backend/src/main/java/com/proshine/system/dto/LoginResponse.java
@@ -1,0 +1,11 @@
+package com.proshine.system.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class LoginResponse {
+    private String token;
+    private List<String> permissionCodes;
+}

--- a/backend/src/main/java/com/proshine/system/dto/UserProfileDto.java
+++ b/backend/src/main/java/com/proshine/system/dto/UserProfileDto.java
@@ -1,0 +1,12 @@
+package com.proshine.system.dto;
+
+import com.proshine.system.entity.User;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class UserProfileDto {
+    private User user;
+    private List<String> permissionCodes;
+}

--- a/backend/src/main/java/com/proshine/system/entity/Permission.java
+++ b/backend/src/main/java/com/proshine/system/entity/Permission.java
@@ -1,0 +1,36 @@
+package com.proshine.system.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "sys_permission")
+public class Permission {
+    @Id
+    @GeneratedValue(generator = "uuid")
+    @Column(length = 32)
+    private String id;
+
+    @Column(nullable = false, length = 64)
+    private String name;
+
+    @Column(nullable = false, unique = true, length = 64)
+    private String code;
+
+    @Column(length = 128)
+    private String path;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 16)
+    private Type type = Type.MENU;
+
+    public enum Type {
+        MENU, BUTTON
+    }
+}

--- a/backend/src/main/java/com/proshine/system/entity/Role.java
+++ b/backend/src/main/java/com/proshine/system/entity/Role.java
@@ -1,0 +1,25 @@
+package com.proshine.system.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "sys_role")
+public class Role {
+    @Id
+    @GeneratedValue(generator = "uuid")
+    @Column(length = 32)
+    private String id;
+
+    @Column(nullable = false, length = 64)
+    private String name;
+
+    @Column(nullable = false, unique = true, length = 64)
+    private String code;
+}

--- a/backend/src/main/java/com/proshine/system/entity/RolePermission.java
+++ b/backend/src/main/java/com/proshine/system/entity/RolePermission.java
@@ -1,0 +1,25 @@
+package com.proshine.system.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "sys_role_permission")
+public class RolePermission {
+    @Id
+    @GeneratedValue(generator = "uuid")
+    @Column(length = 32)
+    private String id;
+
+    @Column(length = 32)
+    private String roleId;
+
+    @Column(length = 32)
+    private String permissionId;
+}

--- a/backend/src/main/java/com/proshine/system/entity/User.java
+++ b/backend/src/main/java/com/proshine/system/entity/User.java
@@ -1,0 +1,36 @@
+package com.proshine.system.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "sys_user")
+public class User {
+    @Id
+    @GeneratedValue(generator = "uuid")
+    @Column(length = 32)
+    private String id;
+
+    @Column(nullable = false, unique = true, length = 64)
+    private String username;
+
+    @Column(nullable = false, length = 128)
+    private String password;
+
+    @Column(length = 64)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 16)
+    private Status status = Status.ACTIVE;
+
+    public enum Status {
+        ACTIVE, DISABLED
+    }
+}

--- a/backend/src/main/java/com/proshine/system/entity/UserRole.java
+++ b/backend/src/main/java/com/proshine/system/entity/UserRole.java
@@ -1,0 +1,25 @@
+package com.proshine.system.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "sys_user_role")
+public class UserRole {
+    @Id
+    @GeneratedValue(generator = "uuid")
+    @Column(length = 32)
+    private String id;
+
+    @Column(length = 32)
+    private String userId;
+
+    @Column(length = 32)
+    private String roleId;
+}

--- a/backend/src/main/java/com/proshine/system/repository/PermissionRepository.java
+++ b/backend/src/main/java/com/proshine/system/repository/PermissionRepository.java
@@ -1,0 +1,9 @@
+package com.proshine.system.repository;
+
+import com.proshine.system.entity.Permission;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PermissionRepository extends JpaRepository<Permission, String> {
+}

--- a/backend/src/main/java/com/proshine/system/repository/RolePermissionRepository.java
+++ b/backend/src/main/java/com/proshine/system/repository/RolePermissionRepository.java
@@ -1,0 +1,13 @@
+package com.proshine.system.repository;
+
+import com.proshine.system.entity.RolePermission;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface RolePermissionRepository extends JpaRepository<RolePermission, String> {
+    List<RolePermission> findByRoleId(String roleId);
+    void deleteByRoleId(String roleId);
+}

--- a/backend/src/main/java/com/proshine/system/repository/RoleRepository.java
+++ b/backend/src/main/java/com/proshine/system/repository/RoleRepository.java
@@ -1,0 +1,9 @@
+package com.proshine.system.repository;
+
+import com.proshine.system.entity.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoleRepository extends JpaRepository<Role, String> {
+}

--- a/backend/src/main/java/com/proshine/system/repository/UserRepository.java
+++ b/backend/src/main/java/com/proshine/system/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.proshine.system.repository;
+
+import com.proshine.system.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, String> {
+    User findByUsername(String username);
+}

--- a/backend/src/main/java/com/proshine/system/repository/UserRoleRepository.java
+++ b/backend/src/main/java/com/proshine/system/repository/UserRoleRepository.java
@@ -1,0 +1,14 @@
+package com.proshine.system.repository;
+
+import com.proshine.system.entity.UserRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface UserRoleRepository extends JpaRepository<UserRole, String> {
+    List<UserRole> findByUserId(String userId);
+    List<UserRole> findByRoleId(String roleId);
+    void deleteByUserId(String userId);
+}

--- a/backend/src/main/java/com/proshine/system/security/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/proshine/system/security/CustomUserDetailsService.java
@@ -1,0 +1,34 @@
+package com.proshine.system.security;
+
+import com.proshine.system.entity.User;
+import com.proshine.system.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserService userService;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userService.findByUsername(username);
+        if (user == null) {
+            throw new UsernameNotFoundException("User not found");
+        }
+        List<String> codes = userService.getPermissionCodes(user.getId());
+        List<GrantedAuthority> authorities = codes.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+        return new org.springframework.security.core.userdetails.User(user.getUsername(), user.getPassword(), authorities);
+    }
+}

--- a/backend/src/main/java/com/proshine/system/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/proshine/system/security/JwtAuthenticationFilter.java
@@ -1,0 +1,46 @@
+package com.proshine.system.security;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final CustomUserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        String header = request.getHeader("Authorization");
+        if (StringUtils.hasText(header) && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+            try {
+                Claims claims = jwtUtil.getClaims(token);
+                String username = claims.getSubject();
+                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (Exception e) {
+                SecurityContextHolder.clearContext();
+            }
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/com/proshine/system/security/JwtUtil.java
+++ b/backend/src/main/java/com/proshine/system/security/JwtUtil.java
@@ -1,0 +1,31 @@
+package com.proshine.system.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    private static final long EXPIRATION = 24 * 60 * 60 * 1000L;
+
+    public String generateToken(String userId, String username) {
+        return Jwts.builder()
+                .setSubject(username)
+                .claim("userId", userId)
+                .setExpiration(new Date(System.currentTimeMillis() + EXPIRATION))
+                .signWith(SignatureAlgorithm.HS512, secret)
+                .compact();
+    }
+
+    public Claims getClaims(String token) {
+        return Jwts.parser().setSigningKey(secret).parseClaimsJws(token).getBody();
+    }
+}

--- a/backend/src/main/java/com/proshine/system/service/RoleService.java
+++ b/backend/src/main/java/com/proshine/system/service/RoleService.java
@@ -1,0 +1,10 @@
+package com.proshine.system.service;
+
+import com.proshine.system.entity.Permission;
+
+import java.util.List;
+
+public interface RoleService {
+    List<Permission> allPermissions();
+    void assignPermissions(String roleId, List<String> permissionIds);
+}

--- a/backend/src/main/java/com/proshine/system/service/UserService.java
+++ b/backend/src/main/java/com/proshine/system/service/UserService.java
@@ -1,0 +1,12 @@
+package com.proshine.system.service;
+
+import com.proshine.system.entity.User;
+
+import java.util.List;
+
+public interface UserService {
+    User findByUsername(String username);
+    List<String> getPermissionCodes(String userId);
+    void assignRole(String userId, List<String> roleIds);
+    User save(User user);
+}

--- a/backend/src/main/java/com/proshine/system/service/impl/RoleServiceImpl.java
+++ b/backend/src/main/java/com/proshine/system/service/impl/RoleServiceImpl.java
@@ -1,0 +1,37 @@
+package com.proshine.system.service.impl;
+
+import com.proshine.system.entity.Permission;
+import com.proshine.system.entity.RolePermission;
+import com.proshine.system.repository.PermissionRepository;
+import com.proshine.system.repository.RolePermissionRepository;
+import com.proshine.system.service.RoleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RoleServiceImpl implements RoleService {
+
+    private final PermissionRepository permissionRepository;
+    private final RolePermissionRepository rolePermissionRepository;
+
+    @Override
+    public List<Permission> allPermissions() {
+        return permissionRepository.findAll();
+    }
+
+    @Override
+    @Transactional
+    public void assignPermissions(String roleId, List<String> permissionIds) {
+        rolePermissionRepository.deleteByRoleId(roleId);
+        for (String pid : permissionIds) {
+            RolePermission rp = new RolePermission();
+            rp.setRoleId(roleId);
+            rp.setPermissionId(pid);
+            rolePermissionRepository.save(rp);
+        }
+    }
+}

--- a/backend/src/main/java/com/proshine/system/service/impl/UserServiceImpl.java
+++ b/backend/src/main/java/com/proshine/system/service/impl/UserServiceImpl.java
@@ -1,0 +1,68 @@
+package com.proshine.system.service.impl;
+
+import com.proshine.system.entity.Permission;
+import com.proshine.system.entity.RolePermission;
+import com.proshine.system.entity.User;
+import com.proshine.system.entity.UserRole;
+import com.proshine.system.repository.PermissionRepository;
+import com.proshine.system.repository.RolePermissionRepository;
+import com.proshine.system.repository.UserRepository;
+import com.proshine.system.repository.UserRoleRepository;
+import com.proshine.system.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final UserRoleRepository userRoleRepository;
+    private final RolePermissionRepository rolePermissionRepository;
+    private final PermissionRepository permissionRepository;
+
+    @Override
+    public User findByUsername(String username) {
+        return userRepository.findByUsername(username);
+    }
+
+    @Override
+    public List<String> getPermissionCodes(String userId) {
+        List<UserRole> userRoles = userRoleRepository.findByUserId(userId);
+        List<String> roleIds = userRoles.stream().map(UserRole::getRoleId).collect(Collectors.toList());
+        if (roleIds.isEmpty()) {
+            return java.util.Collections.emptyList();
+        }
+        List<RolePermission> rp = rolePermissionRepository.findAll().stream()
+                .filter(r -> roleIds.contains(r.getRoleId()))
+                .collect(Collectors.toList());
+        List<String> permIds = rp.stream().map(RolePermission::getPermissionId).collect(Collectors.toList());
+        if (permIds.isEmpty()) {
+            return java.util.Collections.emptyList();
+        }
+        return permissionRepository.findAllById(permIds).stream()
+                .map(Permission::getCode)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void assignRole(String userId, List<String> roleIds) {
+        userRoleRepository.deleteByUserId(userId);
+        for (String roleId : roleIds) {
+            UserRole ur = new UserRole();
+            ur.setUserId(userId);
+            ur.setRoleId(roleId);
+            userRoleRepository.save(ur);
+        }
+    }
+
+    @Override
+    public User save(User user) {
+        return userRepository.save(user);
+    }
+}


### PR DESCRIPTION
## Summary
- add user/role/permission entities and repositories
- implement JWT based security with custom user details
- add authentication, personal center, and management controllers
- secure endpoints via `@PreAuthorize`
- update security configuration for JWT filter

## Testing
- `mvn -q -DskipTests=false test` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6881e12a290c832eb1935aad6f920baf