### PR TITLE
Add organization management backend

### DIFF
--- a/backend/src/main/java/com/proshine/system/controller/OrganizationController.java
+++ b/backend/src/main/java/com/proshine/system/controller/OrganizationController.java
@@ -1,0 +1,97 @@
+package com.proshine.system.controller;
+
+import com.proshine.common.response.ResponseEntity;
+import com.proshine.system.entity.SysOrganization;
+import com.proshine.system.service.OrganizationService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 组织机构控制器
+ */
+@RestController
+@RequestMapping("/api/organization")
+@Slf4j
+public class OrganizationController {
+
+    @Autowired
+    private OrganizationService organizationService;
+
+    /**
+     * 获取组织树结构
+     */
+    @GetMapping("/tree")
+    public ResponseEntity<List<SysOrganization>> tree() {
+        try {
+            log.info("==========/api/organization/tree=============");
+            List<SysOrganization> list = organizationService.getOrganizationTree();
+            return ResponseEntity.success(list);
+        } catch (Exception e) {
+            log.error("获取组织树失败：", e);
+            return ResponseEntity.fail(e.getMessage());
+        }
+    }
+
+    /**
+     * 获取单个组织详情
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<SysOrganization> findById(@PathVariable String id) {
+        try {
+            log.info("==========/api/organization/{} [GET]=============", id);
+            SysOrganization org = organizationService.findById(id);
+            return ResponseEntity.success(org);
+        } catch (Exception e) {
+            log.error("查询组织详情失败：", e);
+            return ResponseEntity.fail(e.getMessage());
+        }
+    }
+
+    /**
+     * 新增组织
+     */
+    @PostMapping
+    public ResponseEntity<SysOrganization> create(@RequestBody SysOrganization organization) {
+        try {
+            log.info("==========/api/organization [POST]=============");
+            SysOrganization saved = organizationService.save(organization);
+            return ResponseEntity.success(saved);
+        } catch (Exception e) {
+            log.error("新增组织失败：", e);
+            return ResponseEntity.fail(e.getMessage());
+        }
+    }
+
+    /**
+     * 编辑组织
+     */
+    @PutMapping("/{id}")
+    public ResponseEntity<SysOrganization> update(@PathVariable String id, @RequestBody SysOrganization organization) {
+        try {
+            log.info("==========/api/organization/{} [PUT]=============", id);
+            SysOrganization updated = organizationService.update(id, organization);
+            return ResponseEntity.success(updated);
+        } catch (Exception e) {
+            log.error("编辑组织失败：", e);
+            return ResponseEntity.fail(e.getMessage());
+        }
+    }
+
+    /**
+     * 删除组织
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable String id) {
+        try {
+            log.info("==========/api/organization/{} [DELETE]=============", id);
+            organizationService.delete(id);
+            return ResponseEntity.success(null);
+        } catch (Exception e) {
+            log.error("删除组织失败：", e);
+            return ResponseEntity.fail(e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/com/proshine/system/entity/SysOrganization.java
+++ b/backend/src/main/java/com/proshine/system/entity/SysOrganization.java
@@ -1,0 +1,64 @@
+package com.proshine.system.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 组织机构实体类
+ */
+@Entity
+@Table(name = "sys_organization")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SysOrganization {
+
+    public static final String DEFAULT_CSTM_ID = "demo";
+
+    @Id
+    @GeneratedValue(generator = "uuid")
+    @GenericGenerator(name = "uuid", strategy = "uuid")
+    @Column(name = "id", columnDefinition = "VARCHAR(32) COMMENT '主键UUID'")
+    private String id;
+
+    @Column(name = "name", columnDefinition = "VARCHAR(100) COMMENT '组织名称'")
+    private String name;
+
+    @Column(name = "code", columnDefinition = "VARCHAR(100) COMMENT '组织编码'")
+    private String code;
+
+    @Column(name = "description", columnDefinition = "TEXT COMMENT '组织描述'")
+    private String description;
+
+    @Column(name = "parent_id", columnDefinition = "VARCHAR(32) COMMENT '上级组织ID'")
+    private String parentId;
+
+    @Column(name = "cstm_id", columnDefinition = "VARCHAR(32) DEFAULT 'demo' COMMENT '客户域'")
+    private String cstmId = DEFAULT_CSTM_ID;
+
+    @Column(name = "create_time", columnDefinition = "DATETIME COMMENT '创建时间'")
+    private LocalDateTime createTime;
+
+    @Column(name = "update_time", columnDefinition = "DATETIME COMMENT '更新时间'")
+    private LocalDateTime updateTime;
+
+    @Transient
+    private List<SysOrganization> children;
+
+    @PrePersist
+    protected void onCreate() {
+        createTime = LocalDateTime.now();
+        updateTime = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updateTime = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/proshine/system/repository/SysOrganizationRepository.java
+++ b/backend/src/main/java/com/proshine/system/repository/SysOrganizationRepository.java
@@ -1,0 +1,18 @@
+package com.proshine.system.repository;
+
+import com.proshine.system.entity.SysOrganization;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * 组织机构数据访问层
+ */
+@Repository
+public interface SysOrganizationRepository extends JpaRepository<SysOrganization, String> {
+
+    List<SysOrganization> findByParentId(String parentId);
+
+    long countByParentId(String parentId);
+}

--- a/backend/src/main/java/com/proshine/system/service/OrganizationService.java
+++ b/backend/src/main/java/com/proshine/system/service/OrganizationService.java
@@ -1,0 +1,38 @@
+package com.proshine.system.service;
+
+import com.proshine.system.entity.SysOrganization;
+
+import java.util.List;
+
+/**
+ * 组织机构服务接口
+ */
+public interface OrganizationService {
+
+    /**
+     * 获取组织树结构
+     *
+     * @return 组织树
+     */
+    List<SysOrganization> getOrganizationTree();
+
+    /**
+     * 根据ID获取组织详情
+     */
+    SysOrganization findById(String id);
+
+    /**
+     * 新增组织
+     */
+    SysOrganization save(SysOrganization organization);
+
+    /**
+     * 更新组织
+     */
+    SysOrganization update(String id, SysOrganization organization);
+
+    /**
+     * 删除组织
+     */
+    void delete(String id);
+}

--- a/backend/src/main/java/com/proshine/system/service/impl/OrganizationServiceImpl.java
+++ b/backend/src/main/java/com/proshine/system/service/impl/OrganizationServiceImpl.java
@@ -1,0 +1,94 @@
+package com.proshine.system.service.impl;
+
+import com.proshine.system.entity.SysOrganization;
+import com.proshine.system.repository.SysOrganizationRepository;
+import com.proshine.system.service.OrganizationService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 组织机构服务实现类
+ */
+@Service
+@Slf4j
+public class OrganizationServiceImpl implements OrganizationService {
+
+    @Autowired
+    private SysOrganizationRepository organizationRepository;
+
+    @Override
+    public List<SysOrganization> getOrganizationTree() {
+        List<SysOrganization> all = organizationRepository.findAll();
+        return buildTree(all, null);
+    }
+
+    private List<SysOrganization> buildTree(List<SysOrganization> all, String parentId) {
+        List<SysOrganization> list = new ArrayList<>();
+        for (SysOrganization org : all) {
+            if (parentId == null) {
+                if (!StringUtils.hasText(org.getParentId())) {
+                    org.setChildren(buildTree(all, org.getId()));
+                    list.add(org);
+                }
+            } else if (parentId.equals(org.getParentId())) {
+                org.setChildren(buildTree(all, org.getId()));
+                list.add(org);
+            }
+        }
+        return list;
+    }
+
+    @Override
+    public SysOrganization findById(String id) {
+        Optional<SysOrganization> optional = organizationRepository.findById(id);
+        if (!optional.isPresent()) {
+            throw new RuntimeException("组织不存在");
+        }
+        return optional.get();
+    }
+
+    @Override
+    @Transactional
+    public SysOrganization save(SysOrganization organization) {
+        organization.setId(null);
+        return organizationRepository.save(organization);
+    }
+
+    @Override
+    @Transactional
+    public SysOrganization update(String id, SysOrganization organization) {
+        Optional<SysOrganization> optional = organizationRepository.findById(id);
+        if (!optional.isPresent()) {
+            throw new RuntimeException("组织不存在");
+        }
+        SysOrganization exist = optional.get();
+        if (StringUtils.hasText(organization.getName())) {
+            exist.setName(organization.getName());
+        }
+        if (StringUtils.hasText(organization.getCode())) {
+            exist.setCode(organization.getCode());
+        }
+        if (StringUtils.hasText(organization.getDescription())) {
+            exist.setDescription(organization.getDescription());
+        }
+        exist.setParentId(organization.getParentId());
+        return organizationRepository.save(exist);
+    }
+
+    @Override
+    @Transactional
+    public void delete(String id) {
+        long count = organizationRepository.countByParentId(id);
+        if (count > 0) {
+            throw new RuntimeException("存在子节点，无法删除");
+        }
+        organizationRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
## Summary
- implement SysOrganization entity with UUID primary key and default customer ID
- add SysOrganizationRepository for data access
- create OrganizationService interface and implementation
- expose CRUD and tree APIs via OrganizationController

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6883274e43c0832ea0de9bde0f47b673