### PR TITLE
Implement position management API logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.11.0",
         "echarts": "^5.6.0",
         "element-plus": "^2.10.4",
+        "file-saver": "^2.0.5",
         "pinia": "^3.0.3",
         "vue": "^3.5.17",
         "vue-router": "^4.5.1"
@@ -2950,6 +2951,12 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/file-saver": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
+      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==",
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "element-plus": "^2.10.4",
     "pinia": "^3.0.3",
     "vue": "^3.5.17",
-    "vue-router": "^4.5.1"
+    "vue-router": "^4.5.1",
+    "file-saver": "^2.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",


### PR DESCRIPTION
## Summary
- connect position management to backend APIs
- support import/export, add, edit, delete
- fetch position list on load
- add file-saver dependency for downloads

## Testing
- `npm run lint` *(fails: Component name "Layout" should always be multi-word, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68833967e8a8832e854b462990a64f04