### PR TITLE
Implement dynamic dropdowns for user editing

### DIFF
--- a/src/api/user.js
+++ b/src/api/user.js
@@ -103,6 +103,30 @@ export const userAPI = {
    */
   checkJobNumberExists(jobNumber) {
     return api.get(`/sys/user/checkJobNumber/${jobNumber}`)
+  },
+
+  /**
+   * 获取部门下拉列表
+   * @returns {Promise}
+   */
+  getAllDepartments() {
+    return api.get('/api/organization/all')
+  },
+
+  /**
+   * 获取职务下拉列表
+   * @returns {Promise}
+   */
+  getAllPositions() {
+    return api.get('/api/position/all')
+  },
+
+  /**
+   * 获取职称下拉列表
+   * @returns {Promise}
+   */
+  getAllTitles() {
+    return api.get('/api/title/all')
   }
 }
 

--- a/src/components/UserEditDialog.vue
+++ b/src/components/UserEditDialog.vue
@@ -71,11 +71,24 @@
       <el-row :gutter="20">
         <el-col :span="8">
           <el-form-item label="所属部门:" prop="department">
-            <el-select v-model="formData.department" placeholder="请选择部门" style="width: 100%">
-              <el-option label="产品部门" value="产品部门" />
-              <el-option label="开发部门" value="开发部门" />
-              <el-option label="销售部门" value="销售部门" />
-              <el-option label="市场部门" value="市场部门" />
+            <el-select
+              v-model="formData.department"
+              placeholder="请选择部门"
+              style="width: 100%"
+              :loading="departmentLoading"
+            >
+              <el-option
+                v-for="item in departments"
+                :key="item.value"
+                :label="item.label"
+                :value="item.value"
+              />
+              <el-option
+                v-if="!departmentLoading && departments.length === 0"
+                disabled
+                label="暂无数据"
+                value=""
+              />
             </el-select>
           </el-form-item>
         </el-col>
@@ -86,11 +99,24 @@
         </el-col>
         <el-col :span="8">
           <el-form-item label="职务:" prop="position">
-            <el-select v-model="formData.position" placeholder="请选择职务" style="width: 100%">
-              <el-option label="产品经理" value="产品经理" />
-              <el-option label="开发工程师" value="开发工程师" />
-              <el-option label="销售经理" value="销售经理" />
-              <el-option label="市场专员" value="市场专员" />
+            <el-select
+              v-model="formData.position"
+              placeholder="请选择职务"
+              style="width: 100%"
+              :loading="positionOptionsLoading"
+            >
+              <el-option
+                v-for="item in positions"
+                :key="item.value"
+                :label="item.label"
+                :value="item.value"
+              />
+              <el-option
+                v-if="!positionOptionsLoading && positions.length === 0"
+                disabled
+                label="暂无数据"
+                value=""
+              />
             </el-select>
           </el-form-item>
         </el-col>
@@ -137,6 +163,9 @@
 import { ref, reactive, watch } from 'vue'
 import { Plus } from '@element-plus/icons-vue'
 import { ElMessage } from 'element-plus'
+import { useOrganizationManagement } from '@/composables/useOrganizationManagement.js'
+import { usePositionManagement } from '@/composables/usePositionManagement.js'
+import { useTitleManagement } from '@/composables/useTitleManagement.js'
 
 export default {
   name: 'UserEditDialog',
@@ -158,6 +187,16 @@ export default {
   setup(props, { emit }) {
     const dialogVisible = ref(false)
     const formRef = ref()
+
+    const {
+      departmentOptions: departments,
+      departmentLoading,
+    } = useOrganizationManagement()
+    const {
+      positionOptions: positions,
+      positionOptionsLoading,
+    } = usePositionManagement()
+    const { titleOptions: titles, titleOptionsLoading } = useTitleManagement()
 
     const formData = reactive({
       name: '',
@@ -280,6 +319,12 @@ export default {
       formRef,
       formData,
       formRules,
+      departments,
+      departmentLoading,
+      positions,
+      positionOptionsLoading,
+      titles,
+      titleOptionsLoading,
       Plus,
       handleClose,
       handleSubmit,

--- a/src/components/UserManagement/UserList/UserDialog.vue
+++ b/src/components/UserManagement/UserList/UserDialog.vue
@@ -90,8 +90,24 @@
         </el-col>
         <el-col :span="12">
           <el-form-item label="所属部门" prop="department">
-            <el-select v-model="userForm.department" placeholder="请选择部门" style="width: 100%">
-              <el-option v-for="item in departments" :key="item.value" :label="item.label" :value="item.value" />
+            <el-select
+              v-model="userForm.department"
+              placeholder="请选择部门"
+              style="width: 100%"
+              :loading="departmentLoading"
+            >
+              <el-option
+                v-for="item in departments"
+                :key="item.value"
+                :label="item.label"
+                :value="item.value"
+              />
+              <el-option
+                v-if="!departmentLoading && departments.length === 0"
+                disabled
+                label="暂无数据"
+                value=""
+              />
             </el-select>
           </el-form-item>
         </el-col>
@@ -105,8 +121,24 @@
         </el-col>
         <el-col :span="12">
           <el-form-item label="职务" prop="position">
-            <el-select v-model="userForm.position" placeholder="请选择职务" style="width: 100%">
-              <el-option v-for="item in positions" :key="item.value" :label="item.label" :value="item.value" />
+            <el-select
+              v-model="userForm.position"
+              placeholder="请选择职务"
+              style="width: 100%"
+              :loading="positionOptionsLoading"
+            >
+              <el-option
+                v-for="item in positions"
+                :key="item.value"
+                :label="item.label"
+                :value="item.value"
+              />
+              <el-option
+                v-if="!positionOptionsLoading && positions.length === 0"
+                disabled
+                label="暂无数据"
+                value=""
+              />
             </el-select>
           </el-form-item>
         </el-col>
@@ -115,8 +147,24 @@
       <el-row :gutter="20">
         <el-col :span="12">
           <el-form-item label="职称" prop="jobTitle">
-            <el-select v-model="userForm.jobTitle" placeholder="请选择职称" style="width: 100%">
-              <el-option v-for="item in titles" :key="item.value" :label="item.label" :value="item.value" />
+            <el-select
+              v-model="userForm.jobTitle"
+              placeholder="请选择职称"
+              style="width: 100%"
+              :loading="titleOptionsLoading"
+            >
+              <el-option
+                v-for="item in titles"
+                :key="item.value"
+                :label="item.label"
+                :value="item.value"
+              />
+              <el-option
+                v-if="!titleOptionsLoading && titles.length === 0"
+                disabled
+                label="暂无数据"
+                value=""
+              />
             </el-select>
           </el-form-item>
         </el-col>
@@ -148,6 +196,9 @@
 import { ref, reactive, watch } from 'vue'
 import { ElMessage } from 'element-plus'
 import { Plus } from '@element-plus/icons-vue'
+import { useOrganizationManagement } from '@/composables/useOrganizationManagement.js'
+import { usePositionManagement } from '@/composables/usePositionManagement.js'
+import { useTitleManagement } from '@/composables/useTitleManagement.js'
 
 const props = defineProps({
   detailDialogVisible: { type: Boolean, default: false },
@@ -163,6 +214,19 @@ const loading = ref(false)
 const avatarList = ref([])
 const faceList = ref([])
 
+const {
+  departmentOptions: departments,
+  departmentLoading
+} = useOrganizationManagement()
+const {
+  positionOptions: positions,
+  positionOptionsLoading
+} = usePositionManagement()
+const {
+  titleOptions: titles,
+  titleOptionsLoading
+} = useTitleManagement()
+
 const userForm = reactive({
   avatar: '',
   faceImage: '',
@@ -177,22 +241,6 @@ const userForm = reactive({
   attendanceNumber: ''
 })
 
-const departments = ref([
-  { label: '技术部', value: '技术部' },
-  { label: '行政部', value: '行政部' }
-])
-
-const positions = ref([
-  { label: '前端工程师', value: '前端工程师' },
-  { label: '后端工程师', value: '后端工程师' },
-  { label: '人事专员', value: '人事专员' }
-])
-
-const titles = ref([
-  { label: '初级工程师', value: '初级工程师' },
-  { label: '中级工程师', value: '中级工程师' },
-  { label: '高级工程师', value: '高级工程师' }
-])
 
 const formRules = {
   avatar: [{ required: true, message: '请上传头像', trigger: 'change' }],

--- a/src/composables/useOrganizationManagement.js
+++ b/src/composables/useOrganizationManagement.js
@@ -14,6 +14,25 @@ export function useOrganizationManagement() {
   const orgDialogMode = ref('add') // 'add' or 'edit'
   const orgActionType = ref('')
 
+  const departmentOptions = ref([])
+  const departmentLoading = ref(false)
+
+  const fetchDepartmentOptions = async () => {
+    departmentLoading.value = true
+    try {
+      const { code, message, data } = await request.get('/api/organization/all')
+      if (code === 200) {
+        departmentOptions.value = data || []
+      } else {
+        ElMessage.error(message || '获取部门下拉失败')
+      }
+    } catch (error) {
+      ElMessage.error(error.message || '获取部门下拉失败')
+    } finally {
+      departmentLoading.value = false
+    }
+  }
+
   // 组织架构数据
   const orgTreeData = ref([
     {
@@ -318,6 +337,7 @@ export function useOrganizationManagement() {
 
   onMounted(() => {
     fetchOrganizationTree()
+    fetchDepartmentOptions()
   })
 
   return {
@@ -335,6 +355,9 @@ export function useOrganizationManagement() {
     orgFormData,
     orgDialogFormData,
     orgMembersData,
+    departmentOptions,
+    departmentLoading,
+    fetchDepartmentOptions,
     orgFormRules,
     orgDialogFormRules,
     

--- a/src/composables/usePositionManagement.js
+++ b/src/composables/usePositionManagement.js
@@ -20,6 +20,25 @@ export function usePositionManagement() {
     description: ''
   })
 
+  const positionOptions = ref([])
+  const positionOptionsLoading = ref(false)
+
+  const fetchPositionOptions = async () => {
+    positionOptionsLoading.value = true
+    try {
+      const { code, message, data } = await request.get('/api/position/all')
+      if (code === 200) {
+        positionOptions.value = data || []
+      } else {
+        ElMessage.error(message || '获取职务下拉失败')
+      }
+    } catch (error) {
+      ElMessage.error(error.message || '获取职务下拉失败')
+    } finally {
+      positionOptionsLoading.value = false
+    }
+  }
+
   const positionFormRules = {
     name: [
       { required: true, message: '请输入职务名称', trigger: 'blur' },
@@ -161,7 +180,10 @@ export function usePositionManagement() {
     }
   }
 
-  onMounted(fetchPositionList)
+  onMounted(() => {
+    fetchPositionList()
+    fetchPositionOptions()
+  })
 
   return {
     positionFormRef,
@@ -183,6 +205,9 @@ export function usePositionManagement() {
     handlePositionDialogClose,
     handlePositionSubmit,
     handleExport,
-    handleImport
+    handleImport,
+    positionOptions,
+    positionOptionsLoading,
+    fetchPositionOptions
   }
 }

--- a/src/composables/useTitleManagement.js
+++ b/src/composables/useTitleManagement.js
@@ -16,6 +16,25 @@ export function useTitleManagement() {
   // 职称数据
   const titleTableData = ref([])
 
+  const titleOptions = ref([])
+  const titleOptionsLoading = ref(false)
+
+  const fetchTitleOptions = async () => {
+    titleOptionsLoading.value = true
+    try {
+      const { code, message, data } = await request.get('/api/title/all')
+      if (code === 200) {
+        titleOptions.value = data || []
+      } else {
+        ElMessage.error(message || '获取职称下拉失败')
+      }
+    } catch (error) {
+      ElMessage.error(error.message || '获取职称下拉失败')
+    } finally {
+      titleOptionsLoading.value = false
+    }
+  }
+
   const titleFormData = reactive({
     id: null,
     name: '',
@@ -181,7 +200,10 @@ export function useTitleManagement() {
     }
   }
 
-  onMounted(fetchTitleList)
+  onMounted(() => {
+    fetchTitleList()
+    fetchTitleOptions()
+  })
 
   return {
     titleFormRef,
@@ -204,6 +226,9 @@ export function useTitleManagement() {
     handleTitleDialogClose,
     handleTitleSubmit,
     handleExport,
-    handleImport
+    handleImport,
+    titleOptions,
+    titleOptionsLoading,
+    fetchTitleOptions
   }
 }

--- a/src/composables/useUserManagement.js
+++ b/src/composables/useUserManagement.js
@@ -47,22 +47,60 @@ export function useUserManagement() {
     status: '正常'
   })
 
-  const departments = ref([
-    { label: '技术部', value: '技术部' },
-    { label: '行政部', value: '行政部' }
-  ])
+  const departments = ref([])
+  const departmentsLoading = ref(false)
+  const positions = ref([])
+  const positionsLoading = ref(false)
+  const titles = ref([])
+  const titlesLoading = ref(false)
 
-  const positions = ref([
-    { label: '前端工程师', value: '前端工程师' },
-    { label: '后端工程师', value: '后端工程师' },
-    { label: '人事专员', value: '人事专员' }
-  ])
+  const fetchDepartments = async () => {
+    departmentsLoading.value = true
+    try {
+      const { code, message, data } = await request.get('/api/organization/all')
+      if (code === 200) {
+        departments.value = data || []
+      } else {
+        ElMessage.error(message || '获取部门失败')
+      }
+    } catch (error) {
+      ElMessage.error(error.message || '获取部门失败')
+    } finally {
+      departmentsLoading.value = false
+    }
+  }
 
-  const titles = ref([
-    { label: '初级工程师', value: '初级工程师' },
-    { label: '中级工程师', value: '中级工程师' },
-    { label: '高级工程师', value: '高级工程师' }
-  ])
+  const fetchPositions = async () => {
+    positionsLoading.value = true
+    try {
+      const { code, message, data } = await request.get('/api/position/all')
+      if (code === 200) {
+        positions.value = data || []
+      } else {
+        ElMessage.error(message || '获取职务失败')
+      }
+    } catch (error) {
+      ElMessage.error(error.message || '获取职务失败')
+    } finally {
+      positionsLoading.value = false
+    }
+  }
+
+  const fetchTitles = async () => {
+    titlesLoading.value = true
+    try {
+      const { code, message, data } = await request.get('/api/title/all')
+      if (code === 200) {
+        titles.value = data || []
+      } else {
+        ElMessage.error(message || '获取职称失败')
+      }
+    } catch (error) {
+      ElMessage.error(error.message || '获取职称失败')
+    } finally {
+      titlesLoading.value = false
+    }
+  }
 
   // 模拟数据
   const treeData = ref([
@@ -348,7 +386,12 @@ export function useUserManagement() {
     logCurrentPage.value = page
   }
 
-  onMounted(fetchUserList)
+  onMounted(() => {
+    fetchUserList()
+    fetchDepartments()
+    fetchPositions()
+    fetchTitles()
+  })
 
   return {
     // 基础数据
@@ -377,8 +420,14 @@ export function useUserManagement() {
     // 表单验证规则
     formRules,
     departments,
+    departmentsLoading,
     positions,
+    positionsLoading,
     titles,
+    titlesLoading,
+    fetchDepartments,
+    fetchPositions,
+    fetchTitles,
     
     // 基础方法
     goToHome,


### PR DESCRIPTION
## Summary
- add department/position/title API helpers
- expose dropdown option loaders in composables
- fetch dropdown data on mount
- display department/position/title lists dynamically in user dialogs

## Testing
- `npm run lint` *(fails: several existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68834fe6ea8c832eb086c5d89f5fb6d9