### PR TITLE
Implement image upload for user edit

### DIFF
--- a/backend/src/main/java/com/proshine/system/config/WebConfig.java
+++ b/backend/src/main/java/com/proshine/system/config/WebConfig.java
@@ -1,0 +1,13 @@
+package com.proshine.system.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/uploads/**").addResourceLocations("file:uploads/");
+    }
+}

--- a/backend/src/main/java/com/proshine/system/controller/FileUploadController.java
+++ b/backend/src/main/java/com/proshine/system/controller/FileUploadController.java
@@ -1,0 +1,25 @@
+package com.proshine.system.controller;
+
+import com.proshine.common.response.ResponseEntity;
+import com.proshine.system.dto.FileUploadResponse;
+import com.proshine.system.service.FileUploadService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/upload")
+public class FileUploadController {
+
+    @Autowired
+    private FileUploadService fileUploadService;
+
+    @PostMapping("/image")
+    public ResponseEntity<FileUploadResponse> uploadImage(@RequestParam MultipartFile file) {
+        FileUploadResponse res = fileUploadService.uploadImage(file);
+        return ResponseEntity.success(res);
+    }
+}

--- a/backend/src/main/java/com/proshine/system/dto/FileUploadResponse.java
+++ b/backend/src/main/java/com/proshine/system/dto/FileUploadResponse.java
@@ -1,0 +1,15 @@
+package com.proshine.system.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Response DTO for file upload
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FileUploadResponse {
+    private String url;
+}

--- a/backend/src/main/java/com/proshine/system/entity/SysFile.java
+++ b/backend/src/main/java/com/proshine/system/entity/SysFile.java
@@ -1,0 +1,35 @@
+package com.proshine.system.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+/**
+ * File entity for storing uploaded file info
+ */
+@Entity
+@Table(name = "sys_file")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SysFile {
+
+    @Id
+    @GeneratedValue(generator = "uuid")
+    @GenericGenerator(name = "uuid", strategy = "uuid")
+    @Column(name = "id", columnDefinition = "VARCHAR(32) COMMENT '主键UUID'")
+    private String id;
+
+    @Column(name = "file_name", columnDefinition = "VARCHAR(255) COMMENT '文件名'")
+    private String fileName;
+
+    @Column(name = "url", columnDefinition = "VARCHAR(255) COMMENT '访问地址'")
+    private String url;
+
+    @Column(name = "upload_time", columnDefinition = "DATETIME COMMENT '上传时间'")
+    private LocalDateTime uploadTime;
+}

--- a/backend/src/main/java/com/proshine/system/repository/SysFileRepository.java
+++ b/backend/src/main/java/com/proshine/system/repository/SysFileRepository.java
@@ -1,0 +1,12 @@
+package com.proshine.system.repository;
+
+import com.proshine.system.entity.SysFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Repository for SysFile
+ */
+@Repository
+public interface SysFileRepository extends JpaRepository<SysFile, String> {
+}

--- a/backend/src/main/java/com/proshine/system/service/FileUploadService.java
+++ b/backend/src/main/java/com/proshine/system/service/FileUploadService.java
@@ -1,0 +1,8 @@
+package com.proshine.system.service;
+
+import com.proshine.system.dto.FileUploadResponse;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FileUploadService {
+    FileUploadResponse uploadImage(MultipartFile file);
+}

--- a/backend/src/main/java/com/proshine/system/service/impl/FileUploadServiceImpl.java
+++ b/backend/src/main/java/com/proshine/system/service/impl/FileUploadServiceImpl.java
@@ -1,0 +1,55 @@
+package com.proshine.system.service.impl;
+
+import com.proshine.system.dto.FileUploadResponse;
+import com.proshine.system.entity.SysFile;
+import com.proshine.system.repository.SysFileRepository;
+import com.proshine.system.service.FileUploadService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+public class FileUploadServiceImpl implements FileUploadService {
+
+    private static final String UPLOAD_DIR = "uploads";
+
+    @Autowired(required = false)
+    private SysFileRepository fileRepository;
+
+    @Override
+    public FileUploadResponse uploadImage(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new RuntimeException("file empty");
+        }
+        String extension = StringUtils.getFilenameExtension(file.getOriginalFilename());
+        String newName = UUID.randomUUID().toString().replace("-", "");
+        if (StringUtils.hasText(extension)) {
+            newName += "." + extension;
+        }
+        File dir = new File(UPLOAD_DIR);
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+        File dest = new File(dir, newName);
+        try {
+            file.transferTo(dest);
+        } catch (IOException e) {
+            throw new RuntimeException("upload fail", e);
+        }
+        String url = "/" + UPLOAD_DIR + "/" + newName;
+        if (fileRepository != null) {
+            SysFile f = new SysFile();
+            f.setFileName(newName);
+            f.setUrl(url);
+            f.setUploadTime(LocalDateTime.now());
+            fileRepository.save(f);
+        }
+        return new FileUploadResponse(url);
+    }
+}

--- a/backend/src/main/java/com/proshine/system/user/dto/UserVO.java
+++ b/backend/src/main/java/com/proshine/system/user/dto/UserVO.java
@@ -17,6 +17,8 @@ public class UserVO {
     private String departmentName;
     private String positionName;
     private String titleName;
+    private String avatarUrl;
+    private String faceImageUrl;
     private String status;
     private LocalDateTime createTime;
 }

--- a/backend/src/main/java/com/proshine/system/user/service/impl/UserServiceImpl.java
+++ b/backend/src/main/java/com/proshine/system/user/service/impl/UserServiceImpl.java
@@ -251,6 +251,8 @@ public class UserServiceImpl implements UserService {
         vo.setDepartmentName(user.getDepartmentName());
         vo.setPositionName(user.getPositionName());
         vo.setTitleName(user.getTitleName());
+        vo.setAvatarUrl(user.getAvatarUrl());
+        vo.setFaceImageUrl(user.getFaceImageUrl());
         vo.setStatus(user.getStatus() != null ? user.getStatus().name() : null);
         vo.setCreateTime(user.getCreateTime());
         return vo;

--- a/src/api/upload.js
+++ b/src/api/upload.js
@@ -1,0 +1,8 @@
+import api from './index'
+
+// Upload image file
+export function uploadFile(data) {
+  return api.post('/api/upload/image', data, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  })
+}


### PR DESCRIPTION
## Summary
- add frontend upload API
- support uploading avatar and face images in user edit dialog
- implement backend file upload controller and service
- expose uploaded files through static resource handler
- include avatarUrl and faceImageUrl in user output

## Testing
- `npx prettier -w src/components/UserEditDialog.vue src/api/upload.js`
- `npx prettier -w backend/src/main/java/com/proshine/system/controller/FileUploadController.java ...`
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688357a8d824832e85d512849abacb43