### PR TITLE
Fix user update request path

### DIFF
--- a/src/api/user.js
+++ b/src/api/user.js
@@ -19,7 +19,7 @@ export const userAPI = {
    * @returns {Promise} 用户详情响应
    */
   getUserById(id) {
-    return api.get(`/sys/user/${id}`)
+    return api.get(`/api/user/${id}`)
   },
 
   /**
@@ -28,7 +28,7 @@ export const userAPI = {
    * @returns {Promise} 保存响应
    */
   saveUser(userData) {
-    return api.post('/sys/user/save', userData)
+    return api.post('/api/user', userData)
   },
 
   /**
@@ -37,7 +37,7 @@ export const userAPI = {
    * @returns {Promise} 更新响应
    */
   updateUser(userData) {
-    return api.post('/sys/user/update', userData)
+    return api.put(`/api/user/${userData.id}`, userData)
   },
 
   /**

--- a/src/composables/useUserManagement.js
+++ b/src/composables/useUserManagement.js
@@ -348,10 +348,23 @@ export function useUserManagement() {
   const handleSaveUser = async () => {
     try {
       await formRef.value.validate()
-      const payload = { ...userForm }
+      const payload = {
+        realName: userForm.realName,
+        gender: userForm.gender,
+        phone: userForm.phone,
+        jobNumber: userForm.jobNumber,
+        departmentId: userForm.department,
+        positionId: userForm.position,
+        titleId: userForm.jobTitle,
+        avatarUrl: userForm.avatar,
+        faceImageUrl: userForm.faceImage,
+        cardNumber: userForm.cardNumber,
+        attendanceNumber: userForm.attendanceNumber,
+        status: userForm.status
+      }
       let res
-      if (isEdit.value && payload.id) {
-        res = await request.put(`/api/user/${payload.id}`, payload)
+      if (isEdit.value && userForm.id) {
+        res = await request.put(`/api/user/${userForm.id}`, payload)
       } else {
         res = await request.post('/api/user', payload)
       }


### PR DESCRIPTION
## Summary
- fix user API paths to RESTful `/api/user`
- map user form fields to backend expected names in `handleSaveUser`

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint', other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6886d471c540832e9f3a28cd72d68286