### PR TITLE
Fix SchemeManagement logical deletion

### DIFF
--- a/backend/src/main/java/com/proshine/system/repository/RoomRepository.java
+++ b/backend/src/main/java/com/proshine/system/repository/RoomRepository.java
@@ -111,6 +111,18 @@ public interface RoomRepository extends JpaRepository<Room, String>, JpaSpecific
     @Query("DELETE FROM Room r WHERE r.id IN :ids AND r.cstmId = :cstmId")
     void deleteByIdsAndCstmId(@Param("ids") List<String> ids, @Param("cstmId") String cstmId);
 
+    /**
+     * 逻辑删除指定客户域的房间
+     *
+     * @param ids    房间ID列表
+     * @param cstmId 客户域ID
+     * @param deleteTime 删除时间戳
+     */
+    @Modifying
+    @Transactional
+    @Query("UPDATE Room r SET r.isDeleted = true, r.deleteTime = :deleteTime WHERE r.id IN :ids AND r.cstmId = :cstmId")
+    void logicalDeleteByIdsAndCstmId(@Param("ids") List<String> ids, @Param("cstmId") String cstmId, @Param("deleteTime") Long deleteTime);
+
     // ========== 逻辑删除相关方法 ==========
 
     /**

--- a/backend/src/main/java/com/proshine/system/service/impl/SchemeManagementServiceImpl.java
+++ b/backend/src/main/java/com/proshine/system/service/impl/SchemeManagementServiceImpl.java
@@ -183,6 +183,9 @@ public class SchemeManagementServiceImpl implements SchemeManagementService {
             
             // 只查询教室类型
             predicates.add(criteriaBuilder.equal(root.get("roomTypeName"), CLASSROOM_TYPE_NAME));
+
+            // 未被逻辑删除
+            predicates.add(criteriaBuilder.equal(root.get("isDeleted"), false));
             
             // 教室名称模糊查询
             if (StringUtils.hasText(condition.getRoomName())) {
@@ -367,8 +370,9 @@ public class SchemeManagementServiceImpl implements SchemeManagementService {
             approvalConfigRepository.deleteByRoomIdInAndCstmId(ids, customerId);
         }
         
-        // 删除Room
-        roomRepository.deleteByIdsAndCstmId(ids, customerId);
+        // 逻辑删除Room
+        long now = System.currentTimeMillis();
+        roomRepository.logicalDeleteByIdsAndCstmId(ids, customerId, now);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- implement `logicalDeleteByIdsAndCstmId` in `RoomRepository`
- call logical delete from `SchemeManagementServiceImpl.batchDeleteClassrooms`
- exclude logically deleted rooms in search

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688a13e81d0c832eb1ac5c245c6d066a